### PR TITLE
[LFXV2-594] fix ruleset.yaml with openfga disabled

### DIFF
--- a/charts/lfx-v2-mailing-list-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-mailing-list-service/templates/ruleset.yaml
@@ -30,8 +30,10 @@ spec:
               relation: writer
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
         {{- else }}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -110,8 +112,10 @@ spec:
               relation: owner
               object: "groupsio_service:{{ "{{- .Request.URL.Captures.uid -}}" }}"
         {{- else }}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt


### PR DESCRIPTION
## Overview

* Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-594

This pull request makes a minor update to the `ruleset.yaml` template for the mailing list service Helm chart. The main change is converting comments about OpenFGA being disabled from regular YAML comments to Helm template comments for better compatibility and clarity in the rendered output.

### Tests

```
==> Printing templates for Helm chart...
helm template lfx-v2-mailing-list-service ./charts/lfx-v2-mailing-list-service --namespace lfx --set image.tag=ad58385
...
# Source: lfx-v2-mailing-list-service/templates/ruleset.yaml
apiVersion: heimdall.dadrus.github.com/v1alpha4
kind: RuleSet
metadata:
  name: lfx-v2-mailing-list-service
  namespace: lfx
spec:
  rules:
    # GroupsIO Services endpoints
    - id: "rule:lfx:lfx-v2-mailing-list-service:groupsio-services:create"
      ...
        - authorizer: allow_all
        - finalizer: create_jwt
     ...

    - id: "rule:lfx:lfx-v2-mailing-list-service:groupsio-services:get"
      ...
        - authorizer: allow_all
   ...
==> Templates printed for Helm chart: lfx-v2-mailing-list-service
```