### PR TITLE
[LFXV2-1379] Fix missing Heimdall ruleset rules for artifact endpoints

### DIFF
--- a/charts/lfx-v2-mailing-list-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-mailing-list-service/templates/ruleset.yaml
@@ -376,3 +376,56 @@ spec:
           config:
             values:
               aud: {{ .Values.app.audience }}
+
+    # GroupsIO Artifact endpoints
+    - id: "rule:lfx:lfx-v2-mailing-list-service:groupsio-artifact:get"
+      match:
+        methods:
+          - GET
+        routes:
+          - path: /groupsio/mailing-lists/:uid/artifacts/:artifact_id
+      execute:
+        - authenticator: oidc
+        - authenticator: anonymous_authenticator
+        {{- if .Values.app.use_oidc_contextualizer }}
+        - contextualizer: oidc_contextualizer
+        {{- end }}
+        {{- if .Values.openfga.enabled }}
+        - authorizer: openfga_check
+          config:
+            values:
+              relation: viewer
+              object: "groupsio_mailing_list:{{ "{{- .Request.URL.Captures.uid -}}" }}"
+        {{- else }}
+        - authorizer: allow_all
+        {{- end }}
+        - finalizer: create_jwt
+          config:
+            values:
+              aud: {{ .Values.app.audience }}
+
+    - id: "rule:lfx:lfx-v2-mailing-list-service:groupsio-artifact:download"
+      match:
+        methods:
+          - GET
+        routes:
+          - path: /groupsio/mailing-lists/:uid/artifacts/:artifact_id/download
+      execute:
+        - authenticator: oidc
+        - authenticator: anonymous_authenticator
+        {{- if .Values.app.use_oidc_contextualizer }}
+        - contextualizer: oidc_contextualizer
+        {{- end }}
+        {{- if .Values.openfga.enabled }}
+        - authorizer: openfga_check
+          config:
+            values:
+              relation: viewer
+              object: "groupsio_mailing_list:{{ "{{- .Request.URL.Captures.uid -}}" }}"
+        {{- else }}
+        - authorizer: allow_all
+        {{- end }}
+        - finalizer: create_jwt
+          config:
+            values:
+              aud: {{ .Values.app.audience }}


### PR DESCRIPTION
## Summary

Adds the missing Heimdall ruleset rules for the two GroupsIO artifact endpoints introduced in #46. Without these rules, Heimdall had no matching rule for requests to the artifact paths and could not issue a JWT with the correct audience, causing the service to reject every request with:

```
authorization failed: expected claims not validated: go-jose/go-jose/jwt: validation failed, invalid audience claim (aud)
```

## Ticket

[LFXV2-1379](https://jira.linuxfoundation.org/browse/LFXV2-1379)

## Changes

Added two rules to `charts/lfx-v2-mailing-list-service/templates/ruleset.yaml`:

- `rule:lfx:lfx-v2-mailing-list-service:groupsio-artifact:get` — `GET /groupsio/mailing-lists/:uid/artifacts/:artifact_id`
- `rule:lfx:lfx-v2-mailing-list-service:groupsio-artifact:download` — `GET /groupsio/mailing-lists/:uid/artifacts/:artifact_id/download`

Both use `viewer` relation on `groupsio_mailing_list:<uid>` for OpenFGA access control, consistent with the other read endpoints on mailing list sub-resources.

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1379]: https://linuxfoundation.atlassian.net/browse/LFXV2-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ