### PR TITLE
[LFXV2-1400] Document indexer contract for mailing list service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ This service uses GOA v3 for API design and code generation:
 
 This applies to method changes, path changes, new endpoints, and deleted endpoints.
 
+### Indexer Contract Documentation
+
+**Whenever you add, remove, or change what this service sends to the indexer (tags, schema fields, IndexingConfig, access messages), you MUST update `docs/indexer-contract.md`:**
+
+- Update the relevant resource type section (schema, tags, access control, search behavior, parent references)
+- Add a new resource type section if a new indexed type is introduced
+
 ### Clean Architecture Structure
 The codebase follows hexagonal/clean architecture principles:
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -19,6 +19,8 @@ This document is the authoritative reference for all data the mailing list servi
 
 ## GroupsIO Service
 
+**Object type:** `groupsio_service`
+
 **Source struct:** `internal/domain/model/grpsio_service.go` — `GroupsIOService`
 
 **NATS subject:** `lfx.index.groupsio_service`
@@ -98,6 +100,8 @@ Published to `lfx.update_access.groupsio_service` on create/update. Deleted via 
 
 ## GroupsIO Service Settings
 
+**Object type:** `groupsio_service_settings`
+
 **Source struct:** `internal/domain/model/grpsio_service.go` — `GrpsIOServiceSettings`
 
 **NATS subject:** `lfx.index.groupsio_service_settings`
@@ -146,6 +150,8 @@ Published to `lfx.update_access.groupsio_service` on create/update. Deleted via 
 ---
 
 ## GroupsIO Mailing List
+
+**Object type:** `groupsio_mailing_list`
 
 **Source struct:** `internal/domain/model/grpsio_mailing_list.go` — `GroupsIOMailingList`
 
@@ -241,6 +247,8 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 
 ## GroupsIO Mailing List Settings
 
+**Object type:** `groupsio_mailing_list_settings`
+
 **Source struct:** `internal/domain/model/grpsio_mailing_list.go` — `GroupsIOMailingListSettings`
 
 **NATS subject:** `lfx.index.groupsio_mailing_list_settings`
@@ -289,6 +297,8 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 ---
 
 ## GroupsIO Member
+
+**Object type:** `groupsio_member`
 
 **Source struct:** `internal/domain/model/grpsio_member.go` — `GrpsIOMember`
 
@@ -375,6 +385,8 @@ The message payload is `{ uid, username, mailing_list_uid }`.
 ---
 
 ## GroupsIO Artifact
+
+**Object type:** `groupsio_artifact`
 
 **Source struct:** `internal/domain/model/grpsio_artifact.go` — `GroupsIOArtifact`
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -74,13 +74,25 @@ Published to `lfx.update_access.groupsio_service` on create/update. Deleted via 
 | `references.writer` | usernames from writers (when settings present) |
 | `references.auditor` | usernames from auditors (when settings present) |
 
-### Search Behavior
+### Search Behavior (IndexingConfig)
 
-No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+| Field | Value |
+|---|---|
+| `object_id` | `{uid}` |
+| `public` | value of `GroupsIOService.Public` |
+| `access_check_object` | `groupsio_service:{uid}` |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `groupsio_service:{uid}` |
+| `history_check_relation` | `auditor` |
+| `sort_name` | `GetGroupName()` falling back to `domain` |
+| `name_and_aliases` | `GetGroupName()`, `domain` (non-empty values) |
+| `fulltext` | space-joined non-empty values of `GetGroupName()`, `domain`, `prefix`, `type` |
 
 ### Parent References
 
-_(handled by the indexer enricher via the `project_uid` tag)_
+| Ref | Condition |
+|---|---|
+| `project:{project_uid}` | Only when `project_uid` is set |
 
 ---
 
@@ -115,9 +127,21 @@ _(handled by the indexer enricher via the `project_uid` tag)_
 | `{uid}` | `abc123` | Direct lookup by UID |
 | `service_uid:{uid}` | `service_uid:abc123` | Namespaced lookup by UID |
 
-### Search Behavior
+### Search Behavior (IndexingConfig)
 
-No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+| Field | Value |
+|---|---|
+| `object_id` | `{uid}` |
+| `access_check_object` | `groupsio_service:{uid}` |
+| `access_check_relation` | `auditor` |
+| `history_check_object` | `groupsio_service:{uid}` |
+| `history_check_relation` | `auditor` |
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `groupsio_service:{uid}` | Always set (uid is the parent service UID) |
 
 ---
 
@@ -184,9 +208,27 @@ Published to `lfx.update_access.groupsio_mailing_list` on create/update. Deleted
 | `references.writer` | usernames from writers (when settings present) |
 | `references.auditor` | usernames from auditors (when settings present) |
 
-### Search Behavior
+### Search Behavior (IndexingConfig)
 
-No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+| Field | Value |
+|---|---|
+| `object_id` | `{uid}` |
+| `public` | value of `GroupsIOMailingList.Public` |
+| `access_check_object` | `groupsio_mailing_list:{uid}` |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `groupsio_mailing_list:{uid}` |
+| `history_check_relation` | `auditor` |
+| `sort_name` | `title` falling back to `group_name` |
+| `name_and_aliases` | `title`, `group_name` (non-empty values) |
+| `fulltext` | space-joined non-empty values of `title`, `group_name`, `description` |
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `groupsio_service:{service_uid}` | Always set |
+| `project:{project_uid}` | Only when `project_uid` is set |
+| `committee:{uid}` | One per associated committee (when `committees` is non-empty) |
 
 ### Reverse Index
 
@@ -228,9 +270,21 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 | `{uid}` | `abc123` | Direct lookup by UID |
 | `mailing_list_uid:{uid}` | `mailing_list_uid:abc123` | Namespaced lookup by UID |
 
-### Search Behavior
+### Search Behavior (IndexingConfig)
 
-No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+| Field | Value |
+|---|---|
+| `object_id` | `{uid}` |
+| `access_check_object` | `groupsio_mailing_list:{uid}` |
+| `access_check_relation` | `auditor` |
+| `history_check_object` | `groupsio_mailing_list:{uid}` |
+| `history_check_relation` | `auditor` |
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `groupsio_mailing_list:{uid}` | Always set (uid is the parent mailing list UID) |
 
 ---
 
@@ -299,9 +353,24 @@ The message payload is `{ uid, username, mailing_list_uid }`.
 
 > **Username transform:** The `username` field in this FGA payload is **not** the raw Groups.io/LFID username. It is the principal value derived via `principal.FromUsername(member.Username)`, which produces an Auth0-style subject (e.g. `auth0|...`). Downstream FGA consumers should expect this format.
 
-### Search Behavior
+### Search Behavior (IndexingConfig)
 
-No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+| Field | Value |
+|---|---|
+| `object_id` | `{uid}` |
+| `access_check_object` | `groupsio_mailing_list:{mailing_list_uid}` |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `groupsio_mailing_list:{mailing_list_uid}` |
+| `history_check_relation` | `auditor` |
+| `sort_name` | `last_name + ", " + first_name`, falling back to `last_name`, `first_name`, or `username` |
+| `name_and_aliases` | full name (`first_name + " " + last_name`), `username`, `email` (non-empty values) |
+| `fulltext` | space-joined non-empty values of `first_name`, `last_name`, `email`, `organization`, `job_title` |
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `groupsio_mailing_list:{mailing_list_uid}` | Always set |
 
 ---
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -1,0 +1,367 @@
+# Indexer Contract — Mailing List Service
+
+This document is the authoritative reference for all data the mailing list service sends to the indexer service, which makes resources searchable via the [query service](https://github.com/linuxfoundation/lfx-v2-query-service).
+
+**Update this document in the same PR as any change to indexer message construction.**
+
+---
+
+## Resource Types
+
+- [GroupsIO Service](#groupsio-service)
+- [GroupsIO Service Settings](#groupsio-service-settings)
+- [GroupsIO Mailing List](#groupsio-mailing-list)
+- [GroupsIO Mailing List Settings](#groupsio-mailing-list-settings)
+- [GroupsIO Member](#groupsio-member)
+- [GroupsIO Artifact](#groupsio-artifact)
+
+---
+
+## GroupsIO Service
+
+**Source struct:** `internal/domain/model/grpsio_service.go` — `GroupsIOService`
+
+**NATS subject:** `lfx.index.groupsio_service`
+
+**Indexed on:** create, update, delete of a GroupsIO service (v1 datastream via `datastream_service_handler.go`).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Service unique identifier |
+| `type` | string | Service type (`primary`, `formation`, `shared`) |
+| `domain` | string | Groups.io domain (e.g. `groups.io`) |
+| `group_id` | int64 (optional) | Groups.io numeric group ID |
+| `status` | string (optional) | Service status |
+| `prefix` | string (optional) | Groups.io group name prefix |
+| `project_uid` | string | v2 UID of the owning project (resolved from v1 SFID) |
+| `project_slug` | string (optional) | Slug of the owning project |
+| `project_name` | string (optional) | Name of the owning project |
+| `url` | string (optional) | Groups.io URL for the service group |
+| `group_name` | string (optional) | Groups.io group name |
+| `public` | bool | Whether the service is publicly accessible |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+| `system_updated_at` | timestamp (optional) | Last modified by a system process |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{uid}` | `abc123` | Direct lookup by UID |
+| `service_uid:{uid}` | `service_uid:abc123` | Namespaced lookup by UID |
+| `project_uid:{value}` | `project_uid:bb4ed8c8-...` | Find services for a project |
+| `project_slug:{value}` | `project_slug:my-project` | Find services by project slug |
+| `service_type:{value}` | `service_type:primary` | Find services by type |
+
+> All tags are only emitted when the value is non-empty.
+
+### Access Control (AccessMessage)
+
+Published to `lfx.update_access.groupsio_service` on create/update. Deleted via `lfx.delete_all_access.groupsio_service` on delete.
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_service` |
+| `public` | value of `GroupsIOService.Public` |
+| `references.project` | `[project_uid]` |
+| `references.writer` | usernames from writers (when settings present) |
+| `references.auditor` | usernames from auditors (when settings present) |
+
+### Search Behavior
+
+No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+
+### Parent References
+
+_(handled by the indexer enricher via the `project_uid` tag)_
+
+---
+
+## GroupsIO Service Settings
+
+**Source struct:** `internal/domain/model/grpsio_service.go` — `GrpsIOServiceSettings`
+
+**NATS subject:** `lfx.index.groupsio_service_settings`
+
+**Indexed on:** create/update of a GroupsIO service when writers or auditors are present. Settings share the same UID as their parent service.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Service UID (same as the parent service) |
+| `writers` | []object | Users with write access. Each object has `username` (string, holds the user ID) |
+| `auditors` | []object | Users with audit access. Each object has `username` (string, holds the user ID) |
+| `last_reviewed_at` | string (optional) | RFC3339 timestamp of the last membership review |
+| `last_reviewed_by` | string (optional) | UID of who performed the last review |
+| `last_audited_by` | string (optional) | UID of who performed the last audit |
+| `last_audited_time` | string (optional) | RFC3339 timestamp of the last audit |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{uid}` | `abc123` | Direct lookup by UID |
+| `service_uid:{uid}` | `service_uid:abc123` | Namespaced lookup by UID |
+
+### Search Behavior
+
+No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+
+---
+
+## GroupsIO Mailing List
+
+**Source struct:** `internal/domain/model/grpsio_mailing_list.go` — `GroupsIOMailingList`
+
+**NATS subject:** `lfx.index.groupsio_mailing_list`
+
+**Indexed on:** create, update, delete of a GroupsIO mailing list (v1 datastream via `datastream_subgroup_handler.go`).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Mailing list unique identifier |
+| `group_id` | int64 (optional) | Groups.io numeric group ID |
+| `group_name` | string (optional) | Groups.io group name |
+| `public` | bool | Whether the mailing list is publicly accessible |
+| `audience_access` | string | Access model: `public`, `approval_required`, or `invite_only` |
+| `type` | string | List type: `announcement`, `discussion_moderated`, or `discussion_open` |
+| `subscriber_count` | int | Current number of subscribers |
+| `committees` | []object (optional) | Associated committees. Each has `uid` (string) and `allowed_voting_statuses` ([]string) |
+| `description` | string | Mailing list description |
+| `title` | string | Mailing list title |
+| `subject_tag` | string (optional) | Email subject tag |
+| `service_uid` | string | UID of the parent GroupsIO service |
+| `project_uid` | string | v2 UID of the owning project (resolved from v1 SFID) |
+| `project_name` | string (optional) | Name of the owning project |
+| `project_slug` | string (optional) | Slug of the owning project |
+| `url` | string (optional) | Groups.io URL for the subgroup |
+| `flags` | []string (optional) | Warning messages about unusual settings |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+| `system_updated_at` | timestamp (optional) | Last modified by a system process |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `groupsio_mailing_list_uid:{uid}` | `groupsio_mailing_list_uid:abc123` | Namespaced lookup by UID |
+| `project_uid:{value}` | `project_uid:bb4ed8c8-...` | Find mailing lists for a project |
+| `service_uid:{value}` | `service_uid:abc123` | Find mailing lists under a service |
+| `type:{value}` | `type:announcement` | Find mailing lists by type |
+| `public:{value}` | `public:true` | Find mailing lists by public status |
+| `audience_access:{value}` | `audience_access:public` | Find mailing lists by audience access |
+| `committee_uid:{value}` | `committee_uid:061a110a-...` | Find mailing lists associated with a committee (one tag per committee) |
+| `committee_voting_status:{value}` | `committee_voting_status:Voting Rep` | Find mailing lists by committee voting status filter |
+| `group_name:{value}` | `group_name:my-project` | Find mailing lists by Groups.io group name |
+
+### Access Control (AccessMessage)
+
+Published to `lfx.update_access.groupsio_mailing_list` on create/update. Deleted via `lfx.delete_all_access.groupsio_mailing_list` on delete.
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `public` | value of `GroupsIOMailingList.Public` |
+| `references.groupsio_service` | `[service_uid]` |
+| `references.committee` | committee UIDs (one per associated committee) |
+| `references.writer` | usernames from writers (when settings present) |
+| `references.auditor` | usernames from auditors (when settings present) |
+
+### Search Behavior
+
+No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+
+### Reverse Index
+
+After a successful update, the handler writes a reverse index to `v1-mappings`:
+- Key: `groupsio-subgroup-gid.{group_id}` → Value: `{uid}`
+
+This allows the member and artifact handlers to resolve the mailing list UID from the Groups.io numeric `group_id`.
+
+---
+
+## GroupsIO Mailing List Settings
+
+**Source struct:** `internal/domain/model/grpsio_mailing_list.go` — `GroupsIOMailingListSettings`
+
+**NATS subject:** `lfx.index.groupsio_mailing_list_settings`
+
+**Indexed on:** create/update of a GroupsIO mailing list when writers or auditors are present. Settings share the same UID as their parent mailing list.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Mailing list UID (same as the parent mailing list) |
+| `writers` | []object | Users with write access. Each object has `username` (string, holds the user ID) |
+| `auditors` | []object | Users with audit access. Each object has `username` (string, holds the user ID) |
+| `last_reviewed_at` | string (optional) | RFC3339 timestamp of the last membership review |
+| `last_reviewed_by` | string (optional) | UID of who performed the last review |
+| `last_audited_by` | string (optional) | UID of who performed the last audit |
+| `last_audited_time` | string (optional) | RFC3339 timestamp of the last audit |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{uid}` | `abc123` | Direct lookup by UID |
+| `mailing_list_uid:{uid}` | `mailing_list_uid:abc123` | Namespaced lookup by UID |
+
+### Search Behavior
+
+No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+
+---
+
+## GroupsIO Member
+
+**Source struct:** `internal/domain/model/grpsio_member.go` — `GrpsIOMember`
+
+**NATS subject:** `lfx.index.groupsio_member`
+
+**Indexed on:** create, update, delete of a GroupsIO mailing list member (v1 datastream via `datastream_member_handler.go`).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Member unique identifier |
+| `mailing_list_uid` | string | UID of the parent mailing list (resolved from `group_id` reverse index) |
+| `member_id` | int64 (optional) | Groups.io numeric member ID |
+| `group_id` | int64 (optional) | Groups.io numeric group ID |
+| `user_id` | string (optional) | User-service ID |
+| `username` | string | Groups.io username (LFID) |
+| `first_name` | string | First name (split from `full_name`) |
+| `last_name` | string | Last name (split from `full_name`) |
+| `email` | string | Member email address (RFC 5322) |
+| `organization` | string (optional) | Member's organization |
+| `job_title` | string (optional) | Member's job title |
+| `groups_email` | string (optional) | Lowercase email as recorded by Groups.io |
+| `groups_full_name` | string (optional) | Lowercase full name as recorded by Groups.io |
+| `committee_email` | string (optional) | Lowercase email from committee service |
+| `committee_full_name` | string (optional) | Lowercase full name from committee service |
+| `committee_id` | string (optional) | Committee UID if member belongs to a committee |
+| `role` | string (optional) | Role within the committee |
+| `voting_status` | string (optional) | Voting status (e.g. `Voting Rep`, `Non-Voting`) |
+| `member_type` | string | `committee` or `direct` |
+| `delivery_mode` | string | Email delivery preference |
+| `delivery_mode_list` | string (optional) | Delivery mode as reported by Groups.io |
+| `mod_status` | string | Moderation status: `none`, `moderator`, or `owner` |
+| `status` | string | Groups.io membership status (e.g. `normal`, `pending`) |
+| `last_reviewed_at` | string (optional) | RFC3339 timestamp of the last review |
+| `last_reviewed_by` | string (optional) | UID of who performed the last review |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+| `system_updated_at` | timestamp (optional) | Last modified by a system process |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{uid}` | `abc123` | Direct lookup by UID |
+| `member_uid:{uid}` | `member_uid:abc123` | Namespaced lookup by UID |
+| `mailing_list_uid:{value}` | `mailing_list_uid:xyz789` | Find members of a mailing list |
+| `username:{value}` | `username:jdoe` | Find members by username |
+| `email:{value}` | `email:jdoe@example.com` | Find members by email |
+| `status:{value}` | `status:normal` | Find members by Groups.io status |
+
+> Tags for `username`, `email`, and `status` are only emitted when the value is non-empty.
+
+### Access Control (AccessMessage)
+
+When a member has a non-empty `username`, the handler also publishes an FGA membership message:
+- **Put member:** `lfx.put_member.groupsio_mailing_list` on create/update
+- **Remove member:** `lfx.remove_member.groupsio_mailing_list` on delete
+
+The message payload is `{ uid, username, mailing_list_uid }`.
+
+### Search Behavior
+
+No `IndexingConfig` is set for this resource type — the indexer uses server-side enrichers.
+
+---
+
+## GroupsIO Artifact
+
+**Source struct:** `internal/domain/model/grpsio_artifact.go` — `GroupsIOArtifact`
+
+**NATS subject:** `lfx.index.groupsio_artifact`
+
+**Indexed on:** create, update, delete of a GroupsIO subgroup artifact (v1 datastream via `datastream_artifact_handler.go`).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `artifact_id` | string | Artifact unique identifier |
+| `group_id` | uint64 | Groups.io numeric group ID |
+| `project_uid` | string (optional) | v2 UID of the owning project (resolved from v1 SFID) |
+| `committee_uid` | string (optional) | v2 UID of the associated committee (resolved from v1 SFID) |
+| `type` | string (optional) | Artifact type (e.g. `file`, `link`) |
+| `media_type` | string (optional) | MIME type of the file |
+| `filename` | string (optional) | Filename of the artifact |
+| `link_url` | string (optional) | URL for link-type artifacts |
+| `download_url` | string (optional) | Groups.io download URL |
+| `s3_key` | string (optional) | S3 object key |
+| `file_uploaded` | bool (optional) | Whether the file has been uploaded; omitted for link-type artifacts |
+| `file_upload_status` | string (optional) | Upload status (e.g. `completed`) |
+| `file_uploaded_at` | timestamp (optional) | When the file was uploaded |
+| `message_ids` | []uint64 (optional) | IDs of associated Groups.io messages |
+| `last_posted_at` | timestamp (optional) | When the artifact was last posted |
+| `last_posted_message_id` | uint64 (optional) | ID of the last posted message |
+| `description` | string (optional) | Artifact description |
+| `created_by` | object (optional) | User who created the artifact (`id`, `username`, `name`, `email`, `profile_picture`) |
+| `last_modified_by` | object (optional) | User who last modified the artifact |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{artifact_id}` | `a323373e-...` | Direct lookup by artifact ID |
+| `group_artifact_id:{artifact_id}` | `group_artifact_id:a323373e-...` | Namespaced lookup by artifact ID |
+| `group_id:{value}` | `group_id:118856` | Find artifacts for a Groups.io group |
+| `project_uid:{value}` | `project_uid:bb4ed8c8-...` | Find artifacts for a project |
+| `committee_uid:{value}` | `committee_uid:061a110a-...` | Find artifacts for a committee |
+
+> `project_uid` and `committee_uid` tags are only emitted when the value is non-empty.
+
+### Access Control (IndexingConfig)
+
+Artifacts use a typed `IndexingConfig` (no server-side enrichers). No FGA `AccessMessage` is published — access is checked at query time via the indexing config.
+
+| Field | Value |
+|---|---|
+| `object_id` | `{artifact_id}` |
+| `public` | `false` (always) |
+| `access_check_object` | `groupsio_artifact:{artifact_id}` |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `groupsio_artifact:{artifact_id}` |
+| `history_check_relation` | `auditor` |
+
+### Search Behavior
+
+| Field | Value |
+|---|---|
+| `fulltext` | `filename` (or `link_url`) + ` ` + `description` |
+| `name_and_aliases` | `filename`, `link_url` (non-empty values only) |
+| `sort_name` | `filename` if set, otherwise `link_url` |
+| `public` | `false` (always) |
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `project:{project_uid}` | Only when `project_uid` is set |
+| `committee:{committee_uid}` | Only when `committee_uid` is set |
+| `groupsio_mailing_list:{group_id}` | Always set (group_id is required) |

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -33,17 +33,22 @@ This document is the authoritative reference for all data the mailing list servi
 | `type` | string | Service type (`primary`, `formation`, `shared`) |
 | `domain` | string | Groups.io domain (e.g. `groups.io`) |
 | `group_id` | int64 (optional) | Groups.io numeric group ID |
-| `status` | string (optional) | Service status |
-| `prefix` | string (optional) | Groups.io group name prefix |
+| `status` | string | Service status; emitted as empty string when not populated |
+| `source` | string | Source system identifier; always `"v1-sync"` for v1 datastream records |
+| `prefix` | string | Groups.io group name prefix; emitted as empty string when not populated |
+| `global_owners` | []string | Global owner list; always emitted as `null`/empty array by v1-sync (not populated by transform) |
+| `parent_service_uid` | string | UID of the parent service for shared type; emitted as empty string by v1-sync |
 | `project_uid` | string | v2 UID of the owning project (resolved from v1 SFID) |
-| `project_slug` | string (optional) | Slug of the owning project |
-| `project_name` | string (optional) | Name of the owning project |
-| `url` | string (optional) | Groups.io URL for the service group |
-| `group_name` | string (optional) | Groups.io group name |
-| `public` | bool | Whether the service is publicly accessible |
+| `project_slug` | string | Slug of the owning project; emitted as empty string when not populated |
+| `project_name` | string | Name of the owning project; emitted as empty string when not populated |
+| `url` | string | Groups.io URL for the service group; emitted as empty string when not populated |
+| `group_name` | string | Groups.io group name; emitted as empty string when not populated |
+| `public` | bool | Whether the service is publicly accessible; emitted as `false` when not populated |
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 | `system_updated_at` | timestamp (optional) | Last modified by a system process |
+
+> **v1-sync transform note:** `transformV1ToGrpsIOService` populates `uid`, `type`, `domain`, `group_id`, `prefix`, `project_uid`, `project_slug`, `source` ("v1-sync"), and timestamps. All other fields (`status`, `global_owners`, `parent_service_uid`, `project_name`, `url`, `group_name`, `public`) are at their Go zero values and will be serialized as empty strings / `false` / `null`.
 
 ### Tags
 
@@ -101,6 +106,8 @@ _(handled by the indexer enricher via the `project_uid` tag)_
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 
+> **v1-sync build note:** `buildServiceSettings` only populates `uid`, `writers`, and `auditors`. The optional review/audit fields and `created_at`/`updated_at` will be at Go zero values (`0001-01-01T00:00:00Z` for timestamps, `null` for optional strings).
+
 ### Tags
 
 | Tag Format | Example | Purpose |
@@ -128,24 +135,27 @@ No `IndexingConfig` is set for this resource type — the indexer uses server-si
 |---|---|---|
 | `uid` | string | Mailing list unique identifier |
 | `group_id` | int64 (optional) | Groups.io numeric group ID |
-| `group_name` | string (optional) | Groups.io group name |
+| `group_name` | string | Groups.io group name; emitted as empty string when not populated |
 | `public` | bool | Whether the mailing list is publicly accessible |
-| `audience_access` | string | Access model: `public`, `approval_required`, or `invite_only` |
+| `audience_access` | string | Access model: `public`, `approval_required`, or `invite_only`; not populated by v1-sync transform — emitted as empty string |
+| `source` | string | Source system identifier; always `"v1-sync"` for v1 datastream records |
 | `type` | string | List type: `announcement`, `discussion_moderated`, or `discussion_open` |
 | `subscriber_count` | int | Current number of subscribers |
 | `committees` | []object (optional) | Associated committees. Each has `uid` (string) and `allowed_voting_statuses` ([]string) |
 | `description` | string | Mailing list description |
 | `title` | string | Mailing list title |
-| `subject_tag` | string (optional) | Email subject tag |
+| `subject_tag` | string | Email subject tag; emitted as empty string when not populated |
 | `service_uid` | string | UID of the parent GroupsIO service |
 | `project_uid` | string | v2 UID of the owning project (resolved from v1 SFID) |
-| `project_name` | string (optional) | Name of the owning project |
-| `project_slug` | string (optional) | Slug of the owning project |
+| `project_name` | string | Name of the owning project; emitted as empty string when not populated |
+| `project_slug` | string | Slug of the owning project; emitted as empty string when not populated |
 | `url` | string (optional) | Groups.io URL for the subgroup |
 | `flags` | []string (optional) | Warning messages about unusual settings |
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 | `system_updated_at` | timestamp (optional) | Last modified by a system process |
+
+> **v1-sync transform note:** `transformV1ToGrpsIOMailingList` populates `uid`, `group_id`, `group_name`, `public` (from `visibility`), `type`, `description`, `title`, `subject_tag`, `url`, `flags`, `service_uid` (from `parent_id`), `project_uid`, `source` ("v1-sync"), `subscriber_count`, `committees`, and timestamps. `audience_access`, `project_name`, and `project_slug` are not set by the transform and will be emitted as empty strings.
 
 ### Tags
 
@@ -209,6 +219,8 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 
+> **v1-sync build note:** `buildMailingListSettings` only populates `uid`, `writers`, and `auditors`. The optional review/audit fields and `created_at`/`updated_at` will be at Go zero values (`0001-01-01T00:00:00Z` for timestamps, `null` for optional strings).
+
 ### Tags
 
 | Tag Format | Example | Purpose |
@@ -238,27 +250,28 @@ No `IndexingConfig` is set for this resource type — the indexer uses server-si
 | `mailing_list_uid` | string | UID of the parent mailing list (resolved from `group_id` reverse index) |
 | `member_id` | int64 (optional) | Groups.io numeric member ID |
 | `group_id` | int64 (optional) | Groups.io numeric group ID |
-| `user_id` | string (optional) | User-service ID |
-| `username` | string | Groups.io username (LFID) |
-| `first_name` | string | First name (split from `full_name`) |
-| `last_name` | string | Last name (split from `full_name`) |
-| `email` | string | Member email address (RFC 5322) |
-| `organization` | string (optional) | Member's organization |
-| `job_title` | string (optional) | Member's job title |
-| `groups_email` | string (optional) | Lowercase email as recorded by Groups.io |
-| `groups_full_name` | string (optional) | Lowercase full name as recorded by Groups.io |
-| `committee_email` | string (optional) | Lowercase email from committee service |
-| `committee_full_name` | string (optional) | Lowercase full name from committee service |
-| `committee_id` | string (optional) | Committee UID if member belongs to a committee |
-| `role` | string (optional) | Role within the committee |
-| `voting_status` | string (optional) | Voting status (e.g. `Voting Rep`, `Non-Voting`) |
-| `member_type` | string | `committee` or `direct` |
-| `delivery_mode` | string | Email delivery preference |
-| `delivery_mode_list` | string (optional) | Delivery mode as reported by Groups.io |
-| `mod_status` | string | Moderation status: `none`, `moderator`, or `owner` |
-| `status` | string | Groups.io membership status (e.g. `normal`, `pending`) |
-| `last_reviewed_at` | string (optional) | RFC3339 timestamp of the last review |
-| `last_reviewed_by` | string (optional) | UID of who performed the last review |
+| `source` | string | Source system identifier; always `"v1-sync"` for v1 datastream records |
+| `user_id` | string (optional) | User-service ID; omitted when empty |
+| `username` | string | Groups.io username (LFID); emitted as empty string when not populated |
+| `first_name` | string | First name (split from `full_name`); emitted as empty string when not populated |
+| `last_name` | string | Last name (split from `full_name`); emitted as empty string when not populated |
+| `email` | string | Member email address (RFC 5322); emitted as empty string when not populated |
+| `organization` | string | Member's organization; emitted as empty string when not populated |
+| `job_title` | string | Member's job title; emitted as empty string when not populated |
+| `groups_email` | string (optional) | Lowercase email as recorded by Groups.io; omitted when empty |
+| `groups_full_name` | string (optional) | Lowercase full name as recorded by Groups.io; omitted when empty |
+| `committee_email` | string (optional) | Lowercase email from committee service; omitted when empty |
+| `committee_full_name` | string (optional) | Lowercase full name from committee service; omitted when empty |
+| `committee_id` | string (optional) | Committee UID if member belongs to a committee; omitted when empty |
+| `role` | string (optional) | Role within the committee; omitted when empty |
+| `voting_status` | string (optional) | Voting status (e.g. `Voting Rep`, `Non-Voting`); omitted when empty |
+| `member_type` | string | `committee` or `direct`; emitted as empty string when not populated |
+| `delivery_mode` | string | Email delivery preference; emitted as empty string when not populated |
+| `delivery_mode_list` | string (optional) | Delivery mode as reported by Groups.io; omitted when empty |
+| `mod_status` | string | Moderation status: `none`, `moderator`, or `owner`; emitted as empty string when not populated |
+| `status` | string | Groups.io membership status (e.g. `normal`, `pending`); emitted as empty string when not populated |
+| `last_reviewed_at` | string or null | RFC3339 timestamp of the last review; emitted as `null` when not set (not omitted) |
+| `last_reviewed_by` | string or null | UID of who performed the last review; emitted as `null` when not set (not omitted) |
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 | `system_updated_at` | timestamp (optional) | Last modified by a system process |
@@ -283,6 +296,8 @@ When a member has a non-empty `username`, the handler also publishes an FGA memb
 - **Remove member:** `lfx.remove_member.groupsio_mailing_list` on delete
 
 The message payload is `{ uid, username, mailing_list_uid }`.
+
+> **Username transform:** The `username` field in this FGA payload is **not** the raw Groups.io/LFID username. It is the principal value derived via `principal.FromUsername(member.Username)`, which produces an Auth0-style subject (e.g. `auth0|...`). Downstream FGA consumers should expect this format.
 
 ### Search Behavior
 
@@ -315,12 +330,12 @@ No `IndexingConfig` is set for this resource type — the indexer uses server-si
 | `file_uploaded` | bool (optional) | Whether the file has been uploaded; omitted for link-type artifacts |
 | `file_upload_status` | string (optional) | Upload status (e.g. `completed`) |
 | `file_uploaded_at` | timestamp (optional) | When the file was uploaded |
-| `message_ids` | []uint64 (optional) | IDs of associated Groups.io messages |
+| `message_ids` | []uint64 (optional) | IDs of associated Groups.io messages; **not populated by `transformV1ToGroupsIOArtifact`** — omitted from v1-sync payloads |
 | `last_posted_at` | timestamp (optional) | When the artifact was last posted |
-| `last_posted_message_id` | uint64 (optional) | ID of the last posted message |
+| `last_posted_message_id` | uint64 (optional) | ID of the last posted message; **not populated by `transformV1ToGroupsIOArtifact`** — omitted from v1-sync payloads |
 | `description` | string (optional) | Artifact description |
-| `created_by` | object (optional) | User who created the artifact (`id`, `username`, `name`, `email`, `profile_picture`) |
-| `last_modified_by` | object (optional) | User who last modified the artifact |
+| `created_by` | object (optional) | User who created the artifact (`id`, `username`, `name`, `email`, `profile_picture`); **not populated by `transformV1ToGroupsIOArtifact`** — omitted from v1-sync payloads |
+| `last_modified_by` | object (optional) | User who last modified the artifact; **not populated by `transformV1ToGroupsIOArtifact`** — omitted from v1-sync payloads |
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 

--- a/internal/domain/model/grpsio_mailing_list.go
+++ b/internal/domain/model/grpsio_mailing_list.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -74,6 +75,81 @@ func (s *GroupsIOMailingListSettings) Tags() []string {
 	}
 
 	return tags
+}
+
+// ParentRefs returns the parent resource references for indexing.
+func (ml *GroupsIOMailingList) ParentRefs() []string {
+	if ml == nil {
+		return nil
+	}
+	var refs []string
+	if ml.ServiceUID != "" {
+		refs = append(refs, fmt.Sprintf("groupsio_service:%s", ml.ServiceUID))
+	}
+	if ml.ProjectUID != "" {
+		refs = append(refs, fmt.Sprintf("project:%s", ml.ProjectUID))
+	}
+	for _, c := range ml.Committees {
+		if c.UID != "" {
+			refs = append(refs, fmt.Sprintf("committee:%s", c.UID))
+		}
+	}
+	return refs
+}
+
+// NameAndAliases returns searchable names for the mailing list.
+func (ml *GroupsIOMailingList) NameAndAliases() []string {
+	if ml == nil {
+		return nil
+	}
+	var names []string
+	if ml.Title != "" {
+		names = append(names, ml.Title)
+	}
+	if ml.GroupName != "" {
+		names = append(names, ml.GroupName)
+	}
+	return names
+}
+
+// SortName returns the primary sort name for the mailing list.
+func (ml *GroupsIOMailingList) SortName() string {
+	if ml == nil {
+		return ""
+	}
+	if ml.Title != "" {
+		return ml.Title
+	}
+	return ml.GroupName
+}
+
+// Fulltext returns a concatenated string for full-text search.
+func (ml *GroupsIOMailingList) Fulltext() string {
+	if ml == nil {
+		return ""
+	}
+	var parts []string
+	if ml.Title != "" {
+		parts = append(parts, ml.Title)
+	}
+	if ml.GroupName != "" {
+		parts = append(parts, ml.GroupName)
+	}
+	if ml.Description != "" {
+		parts = append(parts, ml.Description)
+	}
+	return strings.Join(parts, " ")
+}
+
+// ParentRefs returns the parent mailing list reference for settings indexing.
+func (s *GroupsIOMailingListSettings) ParentRefs() []string {
+	if s == nil {
+		return nil
+	}
+	if s.UID != "" {
+		return []string{fmt.Sprintf("groupsio_mailing_list:%s", s.UID)}
+	}
+	return nil
 }
 
 // Tags generates a consistent set of tags for the mailing list

--- a/internal/domain/model/grpsio_member.go
+++ b/internal/domain/model/grpsio_member.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -92,4 +93,75 @@ func (m *GrpsIOMember) Tags() []string {
 	}
 
 	return tags
+}
+
+// ParentRefs returns the parent resource references for indexing.
+func (m *GrpsIOMember) ParentRefs() []string {
+	if m == nil {
+		return nil
+	}
+	var refs []string
+	if m.MailingListUID != "" {
+		refs = append(refs, fmt.Sprintf("groupsio_mailing_list:%s", m.MailingListUID))
+	}
+	return refs
+}
+
+// NameAndAliases returns searchable names for the member.
+func (m *GrpsIOMember) NameAndAliases() []string {
+	if m == nil {
+		return nil
+	}
+	var names []string
+	if fullName := strings.TrimSpace(m.FirstName + " " + m.LastName); fullName != "" {
+		names = append(names, fullName)
+	}
+	if m.Username != "" {
+		names = append(names, m.Username)
+	}
+	if m.Email != "" {
+		names = append(names, m.Email)
+	}
+	return names
+}
+
+// SortName returns the primary sort name for the member.
+func (m *GrpsIOMember) SortName() string {
+	if m == nil {
+		return ""
+	}
+	if m.LastName != "" && m.FirstName != "" {
+		return m.LastName + ", " + m.FirstName
+	}
+	if m.LastName != "" {
+		return m.LastName
+	}
+	if m.FirstName != "" {
+		return m.FirstName
+	}
+	return m.Username
+}
+
+// Fulltext returns a concatenated string for full-text search.
+func (m *GrpsIOMember) Fulltext() string {
+	if m == nil {
+		return ""
+	}
+	var parts []string
+	if m.FirstName != "" {
+		parts = append(parts, m.FirstName)
+	}
+	if m.LastName != "" {
+		parts = append(parts, m.LastName)
+	}
+	if m.Email != "" {
+		parts = append(parts, m.Email)
+	}
+	if m.Organization != "" {
+		parts = append(parts, m.Organization)
+	}
+	if m.JobTitle != "" {
+		parts = append(parts, m.JobTitle)
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/domain/model/grpsio_service.go
+++ b/internal/domain/model/grpsio_service.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
@@ -130,6 +131,76 @@ func (s *GroupsIOService) GetDomain() string {
 		return s.Domain // Use custom domain if set
 	}
 	return DefaultGroupsIODomain // Default to groups.io
+}
+
+// ParentRefs returns the parent resource references for indexing.
+func (s *GroupsIOService) ParentRefs() []string {
+	if s == nil {
+		return nil
+	}
+	var refs []string
+	if s.ProjectUID != "" {
+		refs = append(refs, fmt.Sprintf("project:%s", s.ProjectUID))
+	}
+	return refs
+}
+
+// NameAndAliases returns searchable names for the service.
+func (s *GroupsIOService) NameAndAliases() []string {
+	if s == nil {
+		return nil
+	}
+	var names []string
+	if n := s.GetGroupName(); n != "" {
+		names = append(names, n)
+	}
+	if s.Domain != "" {
+		names = append(names, s.Domain)
+	}
+	return names
+}
+
+// SortName returns the primary sort name for the service.
+func (s *GroupsIOService) SortName() string {
+	if s == nil {
+		return ""
+	}
+	if n := s.GetGroupName(); n != "" {
+		return n
+	}
+	return s.Domain
+}
+
+// Fulltext returns a concatenated string for full-text search.
+func (s *GroupsIOService) Fulltext() string {
+	if s == nil {
+		return ""
+	}
+	var parts []string
+	if n := s.GetGroupName(); n != "" {
+		parts = append(parts, n)
+	}
+	if s.Domain != "" {
+		parts = append(parts, s.Domain)
+	}
+	if s.Prefix != "" {
+		parts = append(parts, s.Prefix)
+	}
+	if s.Type != "" {
+		parts = append(parts, s.Type)
+	}
+	return strings.Join(parts, " ")
+}
+
+// ParentRefs returns the parent service reference for settings indexing.
+func (s *GrpsIOServiceSettings) ParentRefs() []string {
+	if s == nil {
+		return nil
+	}
+	if s.UID != "" {
+		return []string{fmt.Sprintf("groupsio_service:%s", s.UID)}
+	}
+	return nil
 }
 
 // GetGroupName returns the appropriate group name for Groups.io API calls with comprehensive fallback logic

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	indexertypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
@@ -50,8 +51,22 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 
 	member := transformV1ToGrpsIOMember(uid, mailingListUID, data)
 
+	mailingListRef := fmt.Sprintf("groupsio_mailing_list:%s", mailingListUID)
+	memberConfig := &indexertypes.IndexingConfig{
+		ObjectID:             uid,
+		AccessCheckObject:    mailingListRef,
+		AccessCheckRelation:  "viewer",
+		HistoryCheckObject:   mailingListRef,
+		HistoryCheckRelation: "auditor",
+		ParentRefs:           member.ParentRefs(),
+		NameAndAliases:       member.NameAndAliases(),
+		SortName:             member.SortName(),
+		Fulltext:             member.Fulltext(),
+		Tags:                 member.Tags(),
+	}
+
 	msg := &model.IndexerMessage{Action: action, Tags: member.Tags()}
-	built, err := msg.Build(ctx, member)
+	built, err := msg.BuildWithIndexingConfig(ctx, member, memberConfig)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to build member indexer message", "uid", uid, "error", err)
 		return false

--- a/internal/service/datastream_service_handler.go
+++ b/internal/service/datastream_service_handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	indexertypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
@@ -38,8 +39,24 @@ func HandleDataStreamServiceUpdate(ctx context.Context, uid string, data map[str
 	mKey := fmt.Sprintf("%s.%s", constants.KVMappingPrefixService, uid)
 	action := mappings.ResolveAction(ctx, mKey)
 
+	isPublic := svc.Public
+	svcRef := fmt.Sprintf("groupsio_service:%s", uid)
+	indexingConfig := &indexertypes.IndexingConfig{
+		ObjectID:             uid,
+		Public:               &isPublic,
+		AccessCheckObject:    svcRef,
+		AccessCheckRelation:  "viewer",
+		HistoryCheckObject:   svcRef,
+		HistoryCheckRelation: "auditor",
+		ParentRefs:           svc.ParentRefs(),
+		NameAndAliases:       svc.NameAndAliases(),
+		SortName:             svc.SortName(),
+		Fulltext:             svc.Fulltext(),
+		Tags:                 svc.Tags(),
+	}
+
 	msg := &model.IndexerMessage{Action: action, Tags: svc.Tags()}
-	built, err := msg.Build(ctx, svc)
+	built, err := msg.BuildWithIndexingConfig(ctx, svc, indexingConfig)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to build service indexer message", "uid", uid, "error", err)
 		return false
@@ -53,8 +70,18 @@ func HandleDataStreamServiceUpdate(ctx context.Context, uid string, data map[str
 	// Publish settings indexer message when writers or auditors are present.
 	settings := buildServiceSettings(uid, data)
 	if settings != nil {
+		settingsRef := fmt.Sprintf("groupsio_service:%s", uid)
+		settingsConfig := &indexertypes.IndexingConfig{
+			ObjectID:             uid,
+			AccessCheckObject:    settingsRef,
+			AccessCheckRelation:  "auditor",
+			HistoryCheckObject:   settingsRef,
+			HistoryCheckRelation: "auditor",
+			ParentRefs:           settings.ParentRefs(),
+			Tags:                 settings.Tags(),
+		}
 		settingsMsg := &model.IndexerMessage{Action: action, Tags: settings.Tags()}
-		builtSettings, errSettings := settingsMsg.Build(ctx, settings)
+		builtSettings, errSettings := settingsMsg.BuildWithIndexingConfig(ctx, settings, settingsConfig)
 		if errSettings != nil {
 			slog.ErrorContext(ctx, "failed to build service settings indexer message", "uid", uid, "error", errSettings)
 		}

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	indexertypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
@@ -82,8 +83,24 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 
 	action := mappings.ResolveAction(ctx, mKey)
 
+	isPublic := list.Public
+	listRef := fmt.Sprintf("groupsio_mailing_list:%s", uid)
+	indexingConfig := &indexertypes.IndexingConfig{
+		ObjectID:             uid,
+		Public:               &isPublic,
+		AccessCheckObject:    listRef,
+		AccessCheckRelation:  "viewer",
+		HistoryCheckObject:   listRef,
+		HistoryCheckRelation: "auditor",
+		ParentRefs:           list.ParentRefs(),
+		NameAndAliases:       list.NameAndAliases(),
+		SortName:             list.SortName(),
+		Fulltext:             list.Fulltext(),
+		Tags:                 list.Tags(),
+	}
+
 	msg := &model.IndexerMessage{Action: action, Tags: list.Tags()}
-	built, err := msg.Build(ctx, list)
+	built, err := msg.BuildWithIndexingConfig(ctx, list, indexingConfig)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to build subgroup indexer message", "uid", uid, "error", err)
 		return false
@@ -97,8 +114,18 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 	// Publish settings indexer message when writers or auditors are present.
 	settings := buildMailingListSettings(uid, data)
 	if settings != nil {
+		settingsRef := fmt.Sprintf("groupsio_mailing_list:%s", uid)
+		settingsConfig := &indexertypes.IndexingConfig{
+			ObjectID:             uid,
+			AccessCheckObject:    settingsRef,
+			AccessCheckRelation:  "auditor",
+			HistoryCheckObject:   settingsRef,
+			HistoryCheckRelation: "auditor",
+			ParentRefs:           settings.ParentRefs(),
+			Tags:                 settings.Tags(),
+		}
 		settingsMsg := &model.IndexerMessage{Action: action, Tags: settings.Tags()}
-		builtSettings, errSettings := settingsMsg.Build(ctx, settings)
+		builtSettings, errSettings := settingsMsg.BuildWithIndexingConfig(ctx, settings, settingsConfig)
 		if errSettings != nil {
 			slog.ErrorContext(ctx, "failed to build subgroup settings indexer message", "uid", uid, "error", errSettings)
 		}


### PR DESCRIPTION
## Summary

Creates `docs/indexer-contract.md` as the authoritative reference for all data this service sends to the indexer, following the pattern established by `lfx-v2-committee-service`.

Also adds a `CLAUDE.md` rule requiring this document to be updated whenever indexer message construction changes.

## Ticket

[LFXV2-1400](https://jira.linuxfoundation.org/browse/LFXV2-1400)

## Resource Types Documented

| Resource | NATS Subject | Indexed Via |
|---|---|---|
| GroupsIO Service | `lfx.index.groupsio_service` | v1 datastream |
| GroupsIO Service Settings | `lfx.index.groupsio_service_settings` | v1 datastream |
| GroupsIO Mailing List | `lfx.index.groupsio_mailing_list` | v1 datastream |
| GroupsIO Mailing List Settings | `lfx.index.groupsio_mailing_list_settings` | v1 datastream |
| GroupsIO Member | `lfx.index.groupsio_member` | v1 datastream |
| GroupsIO Artifact | `lfx.index.groupsio_artifact` | v1 datastream |

Each resource section covers: data schema, tags, access control (AccessMessage or IndexingConfig), search behavior (fulltext, name_and_aliases, sort_name, public), and parent references.

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1400]: https://linuxfoundation.atlassian.net/browse/LFXV2-1400