### PR TITLE
[LFXV2-1413] feat: migrate to generic FGA sync format and add FGA contract docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Because this service reuses the same database and infrastructure as the proxied 
 | --- | --- |
 | [docs/api-endpoints.md](docs/api-endpoints.md) | Full list of API endpoints with method, path, and curl examples |
 | [docs/event-processing.md](docs/event-processing.md) | v1→v2 data stream: how DynamoDB change events are consumed, transformed, and published to the indexer and FGA-sync services |
+| [docs/fga-contract.md](docs/fga-contract.md) | Authoritative reference for all FGA sync messages (NATS subjects, payloads, and trigger conditions) |
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -535,10 +535,10 @@ The service publishes messages to the following NATS subjects (primarily via the
 | `lfx.index.groupsio_service` | GroupsIO service indexing events | Indexer message with tags |
 | `lfx.index.groupsio_mailing_list` | Mailing list indexing events | Indexer message with tags |
 | `lfx.index.groupsio_member` | Member indexing events | Indexer message with tags |
-| `lfx.update_access.groupsio_service` | Service access control updates | Access control message |
-| `lfx.delete_all_access.groupsio_service` | Service access control deletion | Access control message |
-| `lfx.update_access.groupsio_mailing_list` | Mailing list access control updates | Access control message |
-| `lfx.delete_all_access.groupsio_mailing_list` | Mailing list access control deletion | Access control message |
+| `lfx.fga-sync.update_access` | Service and mailing list access control create/update | Generic FGA message (`update_access`) |
+| `lfx.fga-sync.delete_access` | Service and mailing list access control delete | Generic FGA message (`delete_access`) |
+| `lfx.fga-sync.member_put` | Add member to mailing list in FGA | Generic FGA message (`member_put`) |
+| `lfx.fga-sync.member_remove` | Remove member from mailing list in FGA | Generic FGA message (`member_remove`) |
 
 ### Message Publisher Interface
 

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -1,0 +1,167 @@
+# FGA Contract — Mailing List Service
+
+This document is the authoritative reference for all messages the mailing list service sends to the fga-sync service, which writes and deletes [OpenFGA](https://openfga.dev/) relationship tuples to enforce access control.
+
+The full OpenFGA type definitions (relations, schema) for all object types are defined in the [platform model](https://github.com/linuxfoundation/lfx-v2-helm/blob/main/charts/lfx-platform/templates/openfga/model.yaml).
+
+**Update this document in the same PR as any change to FGA message construction.**
+
+---
+
+## Object Types
+
+- [GroupsIO Service](#groupsio-service)
+- [GroupsIO Mailing List](#groupsio-mailing-list)
+
+---
+
+## Message Format
+
+This service uses four FGA operation types:
+
+| Subject | Operation | Used for |
+|---|---|---|
+| `lfx.fga-sync.update_access` | `update_access` | Create and update — sets object-level access config and references |
+| `lfx.fga-sync.member_put` | `member_put` | Adds a user to one or more relations on an object |
+| `lfx.fga-sync.member_remove` | `member_remove` | Removes a user from an object; sent on member delete. An empty `relations` array removes all relations for that user on the object |
+| `lfx.fga-sync.delete_access` | `delete_access` | Delete — removes all FGA tuples for the object |
+
+---
+
+## GroupsIO Service
+
+**Source struct:** `internal/domain/model/` — `GroupsIOService` (base + settings)
+
+**Synced on:** create, update, delete of a GroupsIO service.
+
+### update_access
+
+Published to `lfx.fga-sync.update_access` on service create or update.
+
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_service` |
+| `operation` | `update_access` |
+
+#### Data Fields
+
+These fields are carried inside the message `data` object.
+
+| Field | Value |
+|---|---|
+| `uid` | Service UID |
+| `public` | `GroupsIOService.Public` (passed through directly) |
+
+#### Relations
+
+| Relation | Value | Condition |
+|---|---|---|
+| `writer` | Usernames from `GrpsIOServiceSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GrpsIOServiceSettings.Auditors` | Only when `Auditors` is non-empty |
+
+> Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
+
+#### References
+
+| Reference | Value | Condition |
+|---|---|---|
+| `project` | `GroupsIOService.ProjectUID` | Always |
+
+### Delete
+
+On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` with only the service `uid` — all FGA tuples for `groupsio_service:{uid}` are removed by the fga-sync service.
+
+---
+
+## GroupsIO Mailing List
+
+**Source struct:** `internal/domain/model/` — `GroupsIOMailingList` (base + settings)
+
+**Synced on:** create, update, delete of a GroupsIO mailing list (subgroup). Member changes are synced separately via `member_put` and `member_remove`.
+
+### update_access
+
+Published to `lfx.fga-sync.update_access` on mailing list create or update.
+
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `operation` | `update_access` |
+
+#### Data Fields
+
+These fields are carried inside the message `data` object.
+
+| Field | Value |
+|---|---|
+| `uid` | Mailing list UID |
+| `public` | `GroupsIOMailingList.Public` (passed through directly) |
+
+#### Relations
+
+| Relation | Value | Condition |
+|---|---|---|
+| `writer` | Usernames from `GrpsIOMailingListSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GrpsIOMailingListSettings.Auditors` | Only when `Auditors` is non-empty |
+
+> Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
+
+#### References
+
+| Reference | Value | Condition |
+|---|---|---|
+| `groupsio_service` | `GroupsIOMailingList.ServiceUID` | Always |
+| `committee` | `CommitteeUID` per committee | One entry per committee with a non-empty `UID` |
+
+#### Exclude Relations
+
+`exclude_relations: ["member"]` — always set. Individual mailing list members are managed via `member_put` and `member_remove` and must not be overwritten by the `update_access` handler.
+
+### member_put (Member Create/Update)
+
+Published to `lfx.fga-sync.member_put` when a member event is processed and the member has a non-empty `Username`. The username is resolved to an Auth0 `sub` value via `principal.FromUsername` before sending.
+
+The object UID is the **parent mailing list UID**, not the member UID. The parent is resolved from the `group_id` → mailing list reverse index.
+
+#### Member Data
+
+| Field | Value | Condition |
+|---|---|---|
+| `object_type` | `groupsio_mailing_list` | Always |
+| `uid` | `MailingListUID` (parent mailing list) | Always |
+| `username` | Auth0 `sub` of the member | Always (skipped if `Username` is empty) |
+| `relations` | `["member"]` | Always |
+
+### member_remove (Member Delete)
+
+Published to `lfx.fga-sync.member_remove` when a member delete event is processed and the stored mapping contains a non-empty username. The username is resolved to an Auth0 `sub` value via `principal.FromUsername` before sending.
+
+The object UID is the **parent mailing list UID**, recovered from the stored member mapping (`uid|username|mailingListUID`).
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `uid` | `MailingListUID` (parent mailing list) |
+| `username` | Auth0 `sub` of the member |
+| `relations` | `[]` (empty — removes all relations for the user) |
+
+### Delete
+
+On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` with only the mailing list `uid` — all FGA tuples for `groupsio_mailing_list:{uid}` are removed by the fga-sync service.
+
+---
+
+## Triggers
+
+| Operation | Object Type | Subject | Notes |
+|---|---|---|---|
+| Create/update GroupsIO service | `groupsio_service` | `lfx.fga-sync.update_access` | Always sent |
+| Delete GroupsIO service | `groupsio_service` | `lfx.fga-sync.delete_access` | Always sent |
+| Create/update mailing list | `groupsio_mailing_list` | `lfx.fga-sync.update_access` | Always sent |
+| Delete mailing list | `groupsio_mailing_list` | `lfx.fga-sync.delete_access` | Always sent |
+| Create/update member (with username) | `groupsio_mailing_list` | `lfx.fga-sync.member_put` | Skipped if `Username` is empty |
+| Delete member (with username) | `groupsio_mailing_list` | `lfx.fga-sync.member_remove` | Skipped if stored mapping has no username |

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -58,8 +58,8 @@ These fields are carried inside the message `data` object.
 
 | Relation | Value | Condition |
 |---|---|---|
-| `writer` | Usernames from `GrpsIOServiceSettings.Writers` | Only when `Writers` is non-empty |
-| `auditor` | Usernames from `GrpsIOServiceSettings.Auditors` | Only when `Auditors` is non-empty |
+| `writer` | Usernames from `GroupsIOServiceSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GroupsIOServiceSettings.Auditors` | Only when `Auditors` is non-empty |
 
 > Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
 
@@ -105,8 +105,8 @@ These fields are carried inside the message `data` object.
 
 | Relation | Value | Condition |
 |---|---|---|
-| `writer` | Usernames from `GrpsIOMailingListSettings.Writers` | Only when `Writers` is non-empty |
-| `auditor` | Usernames from `GrpsIOMailingListSettings.Auditors` | Only when `Auditors` is non-empty |
+| `writer` | Usernames from `GroupsIOMailingListSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GroupsIOMailingListSettings.Auditors` | Only when `Auditors` is non-empty |
 
 > Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
 
@@ -127,11 +127,17 @@ Published to `lfx.fga-sync.member_put` when a member event is processed and the 
 
 The object UID is the **parent mailing list UID**, not the member UID. The parent is resolved from the `group_id` → mailing list reverse index.
 
-#### Member Data
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `operation` | `member_put` |
+
+#### Data Fields
 
 | Field | Value | Condition |
 |---|---|---|
-| `object_type` | `groupsio_mailing_list` | Always |
 | `uid` | `MailingListUID` (parent mailing list) | Always |
 | `username` | Auth0 `sub` of the member | Always (skipped if `Username` is empty) |
 | `relations` | `["member"]` | Always |

--- a/internal/domain/model/message.go
+++ b/internal/domain/model/message.go
@@ -92,17 +92,33 @@ func (g *IndexerMessage) BuildWithIndexingConfig(ctx context.Context, input any,
 	return msg, nil
 }
 
-// AccessMessage is the schema for the data in the message sent to the fga-sync service
-// These are the fields that the fga-sync service needs in order to update the OpenFGA permissions
-type AccessMessage struct {
+// GenericFGAMessage is the envelope for all FGA sync operations.
+// It uses the generic, resource-agnostic FGA sync handlers.
+type GenericFGAMessage struct {
+	ObjectType string `json:"object_type"` // Resource type, e.g. "groupsio_service"
+	Operation  string `json:"operation"`   // Operation name, e.g. "update_access"
+	Data       any    `json:"data"`        // Operation-specific payload
+}
+
+// FGAUpdateAccessData is the data payload for update_access operations.
+// This is a full sync — any relations not listed (and not excluded) will be removed.
+type FGAUpdateAccessData struct {
+	UID              string              `json:"uid"`
+	Public           bool                `json:"public"`
+	Relations        map[string][]string `json:"relations,omitempty"`
+	References       map[string][]string `json:"references,omitempty"`
+	ExcludeRelations []string            `json:"exclude_relations,omitempty"`
+}
+
+// FGADeleteAccessData is the data payload for delete_access operations.
+type FGADeleteAccessData struct {
 	UID string `json:"uid"`
-	// ObjectType is the type of the object that the message is about, e.g. "groupsio_service"
-	ObjectType string `json:"object_type"`
-	// Public is the public flag for the object
-	Public bool `json:"public"`
-	// Relations is reserved for future use and is intentionally left empty
-	Relations map[string][]string `json:"relations"`
-	// References are used to store the references of the object,
-	// e.g. "project" and its value is the project UID for inheritance
-	References map[string][]string `json:"references"`
+}
+
+// FGAMemberPutData is the data payload for member_put and member_remove operations.
+type FGAMemberPutData struct {
+	UID                   string   `json:"uid"`
+	Username              string   `json:"username"`
+	Relations             []string `json:"relations"`
+	MutuallyExclusiveWith []string `json:"mutually_exclusive_with,omitempty"`
 }

--- a/internal/domain/model/message_test.go
+++ b/internal/domain/model/message_test.go
@@ -253,30 +253,35 @@ func TestMessageAction_Constants(t *testing.T) {
 	assert.Equal(t, MessageAction("deleted"), ActionDeleted)
 }
 
-func TestAccessMessage_Struct(t *testing.T) {
-	// Test that AccessMessage struct can be properly marshaled/unmarshaled
-	accessMsg := AccessMessage{
-		UID:        "access-123",
+func TestGenericFGAMessage_Struct(t *testing.T) {
+	// Test that GenericFGAMessage and FGAUpdateAccessData can be properly marshaled/unmarshaled
+	accessData := FGAUpdateAccessData{
+		UID:    "access-123",
+		Public: true,
+		Relations: map[string][]string{
+			"writer": {"user123"},
+		},
+		References: map[string][]string{
+			"project": {"project-456"},
+		},
+	}
+	msg := GenericFGAMessage{
 		ObjectType: constants.ObjectTypeGroupsIOService,
-		Public:     true,
-		Relations:  map[string][]string{"admin": {"user123"}},
-		References: map[string][]string{"project": {"project-456"}},
+		Operation:  "update_access",
+		Data:       accessData,
 	}
 
 	// Test JSON marshaling
-	data, err := json.Marshal(accessMsg)
+	data, err := json.Marshal(msg)
 	require.NoError(t, err)
 
-	// Test JSON unmarshaling
-	var unmarshaled AccessMessage
+	// Test JSON unmarshaling of the envelope
+	var unmarshaled GenericFGAMessage
 	err = json.Unmarshal(data, &unmarshaled)
 	require.NoError(t, err)
 
-	assert.Equal(t, accessMsg.UID, unmarshaled.UID)
-	assert.Equal(t, accessMsg.ObjectType, unmarshaled.ObjectType)
-	assert.Equal(t, accessMsg.Public, unmarshaled.Public)
-	assert.Equal(t, accessMsg.Relations, unmarshaled.Relations)
-	assert.Equal(t, accessMsg.References, unmarshaled.References)
+	assert.Equal(t, msg.ObjectType, unmarshaled.ObjectType)
+	assert.Equal(t, msg.Operation, unmarshaled.Operation)
 }
 
 // Benchmark for Build method with realistic data

--- a/internal/domain/model/message_test.go
+++ b/internal/domain/model/message_test.go
@@ -282,6 +282,20 @@ func TestGenericFGAMessage_Struct(t *testing.T) {
 
 	assert.Equal(t, msg.ObjectType, unmarshaled.ObjectType)
 	assert.Equal(t, msg.Operation, unmarshaled.Operation)
+
+	// Data is decoded as map[string]any when unmarshaling into GenericFGAMessage
+	dataMap, ok := unmarshaled.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "access-123", dataMap["uid"])
+	assert.Equal(t, true, dataMap["public"])
+
+	relationsMap, ok := dataMap["relations"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"user123"}, relationsMap["writer"])
+
+	referencesMap, ok := dataMap["references"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"project-456"}, referencesMap["project"])
 }
 
 // Benchmark for Build method with realistic data

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -63,12 +63,16 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 	}
 
 	if member.Username != "" {
-		accessMsg := &groupsioMailingListMemberStub{
-			UID:            uid,
-			Username:       principal.FromUsername(member.Username),
-			MailingListUID: mailingListUID,
+		accessMsg := model.GenericFGAMessage{
+			ObjectType: constants.ObjectTypeGroupsIOMailingList,
+			Operation:  "member_put",
+			Data: model.FGAMemberPutData{
+				UID:       mailingListUID,
+				Username:  principal.FromUsername(member.Username),
+				Relations: []string{constants.RelationMember},
+			},
 		}
-		if err := publisher.Access(ctx, constants.PutMemberGroupsIOMailingListSubject, accessMsg); err != nil {
+		if err := publisher.Access(ctx, constants.FGASyncMemberPutSubject, accessMsg); err != nil {
 			slog.WarnContext(ctx, "failed to publish member FGA put message", "uid", uid, "error", err)
 		}
 	}
@@ -114,12 +118,16 @@ func HandleDataStreamMemberDelete(ctx context.Context, uid string, publisher por
 
 	_, username, mailingListUID := parseMemberMappingValue(storedValue)
 	if username != "" {
-		accessMsg := &groupsioMailingListMemberStub{
-			UID:            uid,
-			Username:       principal.FromUsername(username),
-			MailingListUID: mailingListUID,
+		accessMsg := model.GenericFGAMessage{
+			ObjectType: constants.ObjectTypeGroupsIOMailingList,
+			Operation:  "member_remove",
+			Data: model.FGAMemberPutData{
+				UID:       mailingListUID,
+				Username:  principal.FromUsername(username),
+				Relations: []string{},
+			},
 		}
-		if err := publisher.Access(ctx, constants.RemoveMemberGroupsIOMailingListSubject, accessMsg); err != nil {
+		if err := publisher.Access(ctx, constants.FGASyncMemberRemoveSubject, accessMsg); err != nil {
 			slog.WarnContext(ctx, "failed to publish member FGA remove message", "uid", uid, "error", err)
 		}
 	}

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -121,7 +121,64 @@ func TestHandleDataStreamMemberDelete_HappyPath_ACKAndTombstones(t *testing.T) {
 	assert.False(t, nak)
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOMemberSubject, pub.IndexerCalls[0].Subject)
-	assert.Empty(t, pub.AccessCalls, "member delete should not publish access message")
+	assert.Empty(t, pub.AccessCalls, "member delete should not publish access message when no username in mapping")
+
+	assert.True(t, m.IsTombstoned(ctx, mKey))
+}
+
+func TestHandleDataStreamMemberUpdate_WithUsername_PublishesMemberPut(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberUpdate(context.Background(), "mem-1",
+		map[string]any{
+			"group_id":  float64(42),
+			"username":  "alice@example.com",
+			"full_name": "Alice Smith",
+		},
+		pub, m)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	assert.Len(t, pub.AccessCalls, 1)
+	assert.Equal(t, constants.FGASyncMemberPutSubject, pub.AccessCalls[0].Subject)
+
+	msg, ok := pub.AccessCalls[0].Message.(model.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, constants.ObjectTypeGroupsIOMailingList, msg.ObjectType)
+	assert.Equal(t, "member_put", msg.Operation)
+
+	data, ok := msg.Data.(model.FGAMemberPutData)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-1", data.UID)
+	assert.Equal(t, []string{constants.RelationMember}, data.Relations)
+}
+
+func TestHandleDataStreamMemberDelete_WithUsername_PublishesMemberRemove(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	// Store mapping in uid|username|mailingListUID format
+	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-1")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberDelete(ctx, "mem-1", pub, m)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	assert.Len(t, pub.AccessCalls, 1)
+	assert.Equal(t, constants.FGASyncMemberRemoveSubject, pub.AccessCalls[0].Subject)
+
+	msg, ok := pub.AccessCalls[0].Message.(model.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, constants.ObjectTypeGroupsIOMailingList, msg.ObjectType)
+	assert.Equal(t, "member_remove", msg.Operation)
+
+	data, ok := msg.Data.(model.FGAMemberPutData)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-1", data.UID)
+	assert.Empty(t, data.Relations)
 
 	assert.True(t, m.IsTombstoned(ctx, mKey))
 }

--- a/internal/service/datastream_service_handler.go
+++ b/internal/service/datastream_service_handler.go
@@ -65,24 +65,31 @@ func HandleDataStreamServiceUpdate(ctx context.Context, uid string, data map[str
 		}
 	}
 
-	references := map[string][]string{
-		constants.RelationProject: {svc.ProjectUID},
-	}
+	relations := map[string][]string{}
 	if settings != nil {
 		if writers := userInfoUsernames(settings.Writers); len(writers) > 0 {
-			references[constants.RelationWriter] = writers
+			relations[constants.RelationWriter] = writers
 		}
 		if auditors := userInfoUsernames(settings.Auditors); len(auditors) > 0 {
-			references[constants.RelationAuditor] = auditors
+			relations[constants.RelationAuditor] = auditors
 		}
 	}
-	accessMsg := &model.AccessMessage{
-		UID:        uid,
-		ObjectType: constants.ObjectTypeGroupsIOService,
-		Public:     svc.Public,
-		References: references,
+	accessData := model.FGAUpdateAccessData{
+		UID:    uid,
+		Public: svc.Public,
+		References: map[string][]string{
+			constants.RelationProject: {svc.ProjectUID},
+		},
 	}
-	if err := publisher.Access(ctx, constants.UpdateAccessGroupsIOServiceSubject, accessMsg); err != nil {
+	if len(relations) > 0 {
+		accessData.Relations = relations
+	}
+	accessMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOService,
+		Operation:  "update_access",
+		Data:       accessData,
+	}
+	if err := publisher.Access(ctx, constants.FGASyncUpdateAccessSubject, accessMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish service access message", "uid", uid, "error", err)
 	}
 
@@ -114,7 +121,12 @@ func HandleDataStreamServiceDelete(ctx context.Context, uid string, publisher po
 		return pkgerrors.IsTransient(err)
 	}
 
-	if err := publisher.Access(ctx, constants.DeleteAllAccessGroupsIOServiceSubject, uid); err != nil {
+	deleteMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOService,
+		Operation:  "delete_access",
+		Data:       model.FGADeleteAccessData{UID: uid},
+	}
+	if err := publisher.Access(ctx, constants.FGASyncDeleteAccessSubject, deleteMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish service delete access message", "uid", uid, "error", err)
 	}
 

--- a/internal/service/datastream_service_handler_test.go
+++ b/internal/service/datastream_service_handler_test.go
@@ -45,7 +45,7 @@ func TestHandleDataStreamServiceUpdate_HappyPath_ACKAndPublishes(t *testing.T) {
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOServiceSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.UpdateAccessGroupsIOServiceSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncUpdateAccessSubject, pub.AccessCalls[0].Subject)
 
 	_, present := m.GetMappingValue(context.Background(),
 		fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService))
@@ -86,7 +86,7 @@ func TestHandleDataStreamServiceDelete_HappyPath_ACKAndTombstones(t *testing.T) 
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOServiceSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.DeleteAllAccessGroupsIOServiceSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncDeleteAccessSubject, pub.AccessCalls[0].Subject)
 
 	assert.True(t, m.IsTombstoned(context.Background(),
 		fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService)))

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -16,16 +16,6 @@ import (
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/mapconv"
 )
 
-// groupsioMailingListMemberStub represents the minimal data needed for member access control
-type groupsioMailingListMemberStub struct {
-	// UID is the mailing list member ID.
-	UID string `json:"uid"`
-	// Username is the username (i.e. LFID) of the member. This is the identity of the user object in FGA.
-	Username string `json:"username"`
-	// MailingListUID is the mailing list ID for the mailing list the member belongs to.
-	MailingListUID string `json:"mailing_list_uid"`
-}
-
 // HandleDataStreamSubgroupUpdate transforms the v1 payload into a GrpsIOMailingList and publishes
 // indexer + access control messages. Returns true to NAK when the parent service mapping
 // is absent (ordering guarantee) or on transient errors.
@@ -118,21 +108,31 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 			references[constants.RelationCommittee] = append(references[constants.RelationCommittee], committee.UID)
 		}
 	}
+	relations := map[string][]string{}
 	if settings != nil {
 		if writers := userInfoUsernames(settings.Writers); len(writers) > 0 {
-			references[constants.RelationWriter] = writers
+			relations[constants.RelationWriter] = writers
 		}
 		if auditors := userInfoUsernames(settings.Auditors); len(auditors) > 0 {
-			references[constants.RelationAuditor] = auditors
+			relations[constants.RelationAuditor] = auditors
 		}
 	}
-	accessMsg := &model.AccessMessage{
+	accessData := model.FGAUpdateAccessData{
 		UID:        uid,
-		ObjectType: constants.ObjectTypeGroupsIOMailingList,
 		Public:     list.Public,
 		References: references,
+		// member relations are managed separately via member_put and must not be overwritten here
+		ExcludeRelations: []string{constants.RelationMember},
 	}
-	if err := publisher.Access(ctx, constants.UpdateAccessGroupsIOMailingListSubject, accessMsg); err != nil {
+	if len(relations) > 0 {
+		accessData.Relations = relations
+	}
+	accessMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOMailingList,
+		Operation:  "update_access",
+		Data:       accessData,
+	}
+	if err := publisher.Access(ctx, constants.FGASyncUpdateAccessSubject, accessMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish subgroup access message", "uid", uid, "error", err)
 	}
 
@@ -181,7 +181,12 @@ func HandleDataStreamSubgroupDelete(ctx context.Context, uid string, publisher p
 		return pkgerrors.IsTransient(err)
 	}
 
-	if err := publisher.Access(ctx, constants.DeleteAllAccessGroupsIOMailingListSubject, uid); err != nil {
+	deleteMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOMailingList,
+		Operation:  "delete_access",
+		Data:       model.FGADeleteAccessData{UID: uid},
+	}
+	if err := publisher.Access(ctx, constants.FGASyncDeleteAccessSubject, deleteMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish subgroup delete access message", "uid", uid, "error", err)
 	}
 

--- a/internal/service/datastream_subgroup_handler_test.go
+++ b/internal/service/datastream_subgroup_handler_test.go
@@ -75,7 +75,7 @@ func TestHandleDataStreamSubgroupUpdate_HappyPath_ACKAndPublishesAndWritesMappin
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOMailingListSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.UpdateAccessGroupsIOMailingListSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncUpdateAccessSubject, pub.AccessCalls[0].Subject)
 
 	_, present := m.GetMappingValue(context.Background(),
 		fmt.Sprintf("%s.sg-1", constants.KVMappingPrefixSubgroup))
@@ -142,7 +142,7 @@ func TestHandleDataStreamSubgroupDelete_HappyPath_ACKAndTombstones(t *testing.T)
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOMailingListSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.DeleteAllAccessGroupsIOMailingListSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncDeleteAccessSubject, pub.AccessCalls[0].Subject)
 
 	assert.True(t, m.IsTombstoned(context.Background(),
 		fmt.Sprintf("%s.sg-1", constants.KVMappingPrefixSubgroup)))

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -13,15 +13,11 @@ const (
 	IndexGroupsIOMemberSubject               = "lfx.index.groupsio_member"
 	IndexGroupsIOArtifactSubject             = "lfx.index.groupsio_artifact"
 
-	// Access control subjects for OpenFGA integration
-	UpdateAccessGroupsIOServiceSubject    = "lfx.update_access.groupsio_service"
-	DeleteAllAccessGroupsIOServiceSubject = "lfx.delete_all_access.groupsio_service"
-
-	UpdateAccessGroupsIOMailingListSubject    = "lfx.update_access.groupsio_mailing_list"
-	DeleteAllAccessGroupsIOMailingListSubject = "lfx.delete_all_access.groupsio_mailing_list"
-
-	PutMemberGroupsIOMailingListSubject    = "lfx.put_member.groupsio_mailing_list"
-	RemoveMemberGroupsIOMailingListSubject = "lfx.remove_member.groupsio_mailing_list"
+	// Generic FGA sync subjects for OpenFGA integration
+	FGASyncUpdateAccessSubject = "lfx.fga-sync.update_access"
+	FGASyncDeleteAccessSubject = "lfx.fga-sync.delete_access"
+	FGASyncMemberPutSubject    = "lfx.fga-sync.member_put"
+	FGASyncMemberRemoveSubject = "lfx.fga-sync.member_remove"
 
 	// Committee event subjects from committee-api
 	CommitteeMemberCreatedSubject = "lfx.committee-api.committee_member.created"


### PR DESCRIPTION
## Summary

- Replace legacy type-specific FGA NATS subjects (`lfx.update_access.*`, `lfx.delete_all_access.*`, `lfx.put_member.*`, `lfx.remove_member.*`) with generic `lfx.fga-sync.*` subjects used across all v2 services
- Introduce `GenericFGAMessage` envelope with `FGAUpdateAccessData`, `FGADeleteAccessData`, and `FGAMemberPutData` payload types in the domain model
- Separate user relations (`writer`, `auditor`) from object references (`project`, `groupsio_service`, `committee`) in `update_access` payloads
- Add `exclude_relations: ["member"]` to mailing list `update_access` so per-user member tuples managed by `member_put` are not overwritten
- Switch member deletes from `put_member` to the `member_remove` operation with empty `relations`
- Add `docs/fga-contract.md` as the authoritative reference for all FGA sync messages, linked from the README

## Ticket

[LFXV2-1413](https://jira.linuxfoundation.org/browse/LFXV2-1413)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `datastream_service_handler_test.go` updated to assert `FGASyncUpdateAccessSubject` / `FGASyncDeleteAccessSubject`
- [x] `datastream_subgroup_handler_test.go` updated similarly
- [x] `message_test.go` updated from `AccessMessage` to `GenericFGAMessage`

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1413]: https://linuxfoundation.atlassian.net/browse/LFXV2-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ