### PR TITLE
[LFXV2-1418] feat: add project_uid and project_slug to groupsio_member indexed records

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Because this service reuses the same database and infrastructure as the proxied 
 | --- | --- |
 | [docs/api-endpoints.md](docs/api-endpoints.md) | Full list of API endpoints with method, path, and curl examples |
 | [docs/event-processing.md](docs/event-processing.md) | v1→v2 data stream: how DynamoDB change events are consumed, transformed, and published to the indexer and FGA-sync services |
+| [docs/fga-contract.md](docs/fga-contract.md) | Authoritative reference for all FGA sync messages (NATS subjects, payloads, and trigger conditions) |
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -535,10 +535,10 @@ The service publishes messages to the following NATS subjects (primarily via the
 | `lfx.index.groupsio_service` | GroupsIO service indexing events | Indexer message with tags |
 | `lfx.index.groupsio_mailing_list` | Mailing list indexing events | Indexer message with tags |
 | `lfx.index.groupsio_member` | Member indexing events | Indexer message with tags |
-| `lfx.update_access.groupsio_service` | Service access control updates | Access control message |
-| `lfx.delete_all_access.groupsio_service` | Service access control deletion | Access control message |
-| `lfx.update_access.groupsio_mailing_list` | Mailing list access control updates | Access control message |
-| `lfx.delete_all_access.groupsio_mailing_list` | Mailing list access control deletion | Access control message |
+| `lfx.fga-sync.update_access` | Service and mailing list access control create/update | Generic FGA message (`update_access`) |
+| `lfx.fga-sync.delete_access` | Service and mailing list access control delete | Generic FGA message (`delete_access`) |
+| `lfx.fga-sync.member_put` | Add member to mailing list in FGA | Generic FGA message (`member_put`) |
+| `lfx.fga-sync.member_remove` | Remove member from mailing list in FGA | Generic FGA message (`member_remove`) |
 
 ### Message Publisher Interface
 

--- a/cmd/mailing-list-api/data_stream.go
+++ b/cmd/mailing-list-api/data_stream.go
@@ -31,7 +31,7 @@ func handleDataStream(ctx context.Context, wg *sync.WaitGroup) error {
 
 	natsClient := service.GetNATSClient(ctx)
 
-	handler := eventing.NewEventHandler(service.MessagePublisher(ctx), service.MappingReaderWriter(ctx))
+	handler := eventing.NewEventHandler(service.MessagePublisher(ctx), service.MappingReaderWriter(ctx), infraNATS.NewNATSProjectLookup(natsClient))
 	streamConsumer := infraNATS.NewDataStreamConsumer(handler)
 
 	cfg := dataStreamConfig()

--- a/cmd/mailing-list-api/eventing/handler.go
+++ b/cmd/mailing-list-api/eventing/handler.go
@@ -26,17 +26,20 @@ const (
 // eventHandler implements port.DataEventHandler and routes KV events to the
 // appropriate per-entity handler based on the key prefix.
 type eventHandler struct {
-	publisher port.MessagePublisher
-	mappings  port.MappingReaderWriter
+	publisher     port.MessagePublisher
+	mappings      port.MappingReaderWriter
+	projectLookup port.ProjectLookup
 }
 
 // NewEventHandler constructs a DataEventHandler for GroupsIO entities.
 // publisher is used to emit indexer and access control messages.
 // mappings is the v1-mappings abstraction used for idempotency tracking.
-func NewEventHandler(publisher port.MessagePublisher, mappings port.MappingReaderWriter) port.DataEventHandler {
+// projectLookup is used by the subgroup handler to fetch the project slug.
+func NewEventHandler(publisher port.MessagePublisher, mappings port.MappingReaderWriter, projectLookup port.ProjectLookup) port.DataEventHandler {
 	return &eventHandler{
-		publisher: publisher,
-		mappings:  mappings,
+		publisher:     publisher,
+		mappings:      mappings,
+		projectLookup: projectLookup,
 	}
 }
 
@@ -58,7 +61,7 @@ func (h *eventHandler) HandleChange(ctx context.Context, key string, data map[st
 		if isSoftDelete {
 			return service.HandleDataStreamSubgroupDelete(ctx, uid, h.publisher, h.mappings)
 		}
-		return service.HandleDataStreamSubgroupUpdate(ctx, uid, data, h.publisher, h.mappings)
+		return service.HandleDataStreamSubgroupUpdate(ctx, uid, data, h.publisher, h.mappings, h.projectLookup)
 
 	case strings.HasPrefix(key, kvPrefixMember):
 		uid := key[len(kvPrefixMember):]

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -1,0 +1,167 @@
+# FGA Contract — Mailing List Service
+
+This document is the authoritative reference for all messages the mailing list service sends to the fga-sync service, which writes and deletes [OpenFGA](https://openfga.dev/) relationship tuples to enforce access control.
+
+The full OpenFGA type definitions (relations, schema) for all object types are defined in the [platform model](https://github.com/linuxfoundation/lfx-v2-helm/blob/main/charts/lfx-platform/templates/openfga/model.yaml).
+
+**Update this document in the same PR as any change to FGA message construction.**
+
+---
+
+## Object Types
+
+- [GroupsIO Service](#groupsio-service)
+- [GroupsIO Mailing List](#groupsio-mailing-list)
+
+---
+
+## Message Format
+
+This service uses four FGA operation types:
+
+| Subject | Operation | Used for |
+|---|---|---|
+| `lfx.fga-sync.update_access` | `update_access` | Create and update — sets object-level access config and references |
+| `lfx.fga-sync.member_put` | `member_put` | Adds a user to one or more relations on an object |
+| `lfx.fga-sync.member_remove` | `member_remove` | Removes a user from an object; sent on member delete. An empty `relations` array removes all relations for that user on the object |
+| `lfx.fga-sync.delete_access` | `delete_access` | Delete — removes all FGA tuples for the object |
+
+---
+
+## GroupsIO Service
+
+**Source struct:** `internal/domain/model/` — `GroupsIOService` (base + settings)
+
+**Synced on:** create, update, delete of a GroupsIO service.
+
+### update_access
+
+Published to `lfx.fga-sync.update_access` on service create or update.
+
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_service` |
+| `operation` | `update_access` |
+
+#### Data Fields
+
+These fields are carried inside the message `data` object.
+
+| Field | Value |
+|---|---|
+| `uid` | Service UID |
+| `public` | `GroupsIOService.Public` (passed through directly) |
+
+#### Relations
+
+| Relation | Value | Condition |
+|---|---|---|
+| `writer` | Usernames from `GrpsIOServiceSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GrpsIOServiceSettings.Auditors` | Only when `Auditors` is non-empty |
+
+> Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
+
+#### References
+
+| Reference | Value | Condition |
+|---|---|---|
+| `project` | `GroupsIOService.ProjectUID` | Always |
+
+### Delete
+
+On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` with only the service `uid` — all FGA tuples for `groupsio_service:{uid}` are removed by the fga-sync service.
+
+---
+
+## GroupsIO Mailing List
+
+**Source struct:** `internal/domain/model/` — `GroupsIOMailingList` (base + settings)
+
+**Synced on:** create, update, delete of a GroupsIO mailing list (subgroup). Member changes are synced separately via `member_put` and `member_remove`.
+
+### update_access
+
+Published to `lfx.fga-sync.update_access` on mailing list create or update.
+
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `operation` | `update_access` |
+
+#### Data Fields
+
+These fields are carried inside the message `data` object.
+
+| Field | Value |
+|---|---|
+| `uid` | Mailing list UID |
+| `public` | `GroupsIOMailingList.Public` (passed through directly) |
+
+#### Relations
+
+| Relation | Value | Condition |
+|---|---|---|
+| `writer` | Usernames from `GrpsIOMailingListSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GrpsIOMailingListSettings.Auditors` | Only when `Auditors` is non-empty |
+
+> Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
+
+#### References
+
+| Reference | Value | Condition |
+|---|---|---|
+| `groupsio_service` | `GroupsIOMailingList.ServiceUID` | Always |
+| `committee` | `CommitteeUID` per committee | One entry per committee with a non-empty `UID` |
+
+#### Exclude Relations
+
+`exclude_relations: ["member"]` — always set. Individual mailing list members are managed via `member_put` and `member_remove` and must not be overwritten by the `update_access` handler.
+
+### member_put (Member Create/Update)
+
+Published to `lfx.fga-sync.member_put` when a member event is processed and the member has a non-empty `Username`. The username is resolved to an Auth0 `sub` value via `principal.FromUsername` before sending.
+
+The object UID is the **parent mailing list UID**, not the member UID. The parent is resolved from the `group_id` → mailing list reverse index.
+
+#### Member Data
+
+| Field | Value | Condition |
+|---|---|---|
+| `object_type` | `groupsio_mailing_list` | Always |
+| `uid` | `MailingListUID` (parent mailing list) | Always |
+| `username` | Auth0 `sub` of the member | Always (skipped if `Username` is empty) |
+| `relations` | `["member"]` | Always |
+
+### member_remove (Member Delete)
+
+Published to `lfx.fga-sync.member_remove` when a member delete event is processed and the stored mapping contains a non-empty username. The username is resolved to an Auth0 `sub` value via `principal.FromUsername` before sending.
+
+The object UID is the **parent mailing list UID**, recovered from the stored member mapping (`uid|username|mailingListUID`).
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `uid` | `MailingListUID` (parent mailing list) |
+| `username` | Auth0 `sub` of the member |
+| `relations` | `[]` (empty — removes all relations for the user) |
+
+### Delete
+
+On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` with only the mailing list `uid` — all FGA tuples for `groupsio_mailing_list:{uid}` are removed by the fga-sync service.
+
+---
+
+## Triggers
+
+| Operation | Object Type | Subject | Notes |
+|---|---|---|---|
+| Create/update GroupsIO service | `groupsio_service` | `lfx.fga-sync.update_access` | Always sent |
+| Delete GroupsIO service | `groupsio_service` | `lfx.fga-sync.delete_access` | Always sent |
+| Create/update mailing list | `groupsio_mailing_list` | `lfx.fga-sync.update_access` | Always sent |
+| Delete mailing list | `groupsio_mailing_list` | `lfx.fga-sync.delete_access` | Always sent |
+| Create/update member (with username) | `groupsio_mailing_list` | `lfx.fga-sync.member_put` | Skipped if `Username` is empty |
+| Delete member (with username) | `groupsio_mailing_list` | `lfx.fga-sync.member_remove` | Skipped if stored mapping has no username |

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -58,8 +58,8 @@ These fields are carried inside the message `data` object.
 
 | Relation | Value | Condition |
 |---|---|---|
-| `writer` | Usernames from `GrpsIOServiceSettings.Writers` | Only when `Writers` is non-empty |
-| `auditor` | Usernames from `GrpsIOServiceSettings.Auditors` | Only when `Auditors` is non-empty |
+| `writer` | Usernames from `GroupsIOServiceSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GroupsIOServiceSettings.Auditors` | Only when `Auditors` is non-empty |
 
 > Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
 
@@ -105,8 +105,8 @@ These fields are carried inside the message `data` object.
 
 | Relation | Value | Condition |
 |---|---|---|
-| `writer` | Usernames from `GrpsIOMailingListSettings.Writers` | Only when `Writers` is non-empty |
-| `auditor` | Usernames from `GrpsIOMailingListSettings.Auditors` | Only when `Auditors` is non-empty |
+| `writer` | Usernames from `GroupsIOMailingListSettings.Writers` | Only when `Writers` is non-empty |
+| `auditor` | Usernames from `GroupsIOMailingListSettings.Auditors` | Only when `Auditors` is non-empty |
 
 > Usernames are extracted from the `Username` pointer of each `UserInfo` entry. Users with a nil or empty `Username` are skipped.
 
@@ -127,11 +127,17 @@ Published to `lfx.fga-sync.member_put` when a member event is processed and the 
 
 The object UID is the **parent mailing list UID**, not the member UID. The parent is resolved from the `group_id` → mailing list reverse index.
 
-#### Member Data
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `groupsio_mailing_list` |
+| `operation` | `member_put` |
+
+#### Data Fields
 
 | Field | Value | Condition |
 |---|---|---|
-| `object_type` | `groupsio_mailing_list` | Always |
 | `uid` | `MailingListUID` (parent mailing list) | Always |
 | `username` | Auth0 `sub` of the member | Always (skipped if `Username` is empty) |
 | `relations` | `["member"]` | Always |

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -326,9 +326,13 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 | `status` | string | Groups.io membership status (e.g. `normal`, `pending`); emitted as empty string when not populated |
 | `last_reviewed_at` | string or null | RFC3339 timestamp of the last review; emitted as `null` when not set (not omitted) |
 | `last_reviewed_by` | string or null | UID of who performed the last review; emitted as `null` when not set (not omitted) |
+| `project_uid` | string (optional) | v2 UID of the owning project (inherited from parent mailing list); omitted when empty |
+| `project_slug` | string (optional) | URL slug of the owning project (fetched via `lfx.projects-api.get_slug`); omitted when empty |
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 | `system_updated_at` | timestamp (optional) | Last modified by a system process |
+
+> **v1-sync note:** `project_uid` and `project_slug` are resolved by the subgroup handler (written to `groupsio-subgroup-project.{subgroup_uid}`) and read by the member handler before indexing. The member handler NAKs if the project mapping is absent, ensuring the subgroup is fully processed first.
 
 ### Tags
 
@@ -340,8 +344,9 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 | `username:{value}` | `username:jdoe` | Find members by username |
 | `email:{value}` | `email:jdoe@example.com` | Find members by email |
 | `status:{value}` | `status:normal` | Find members by Groups.io status |
+| `project_uid:{value}` | `project_uid:bb4ed8c8-...` | Find members belonging to a project |
 
-> Tags for `username`, `email`, and `status` are only emitted when the value is non-empty.
+> Tags for `username`, `email`, `status`, and `project_uid` are only emitted when the value is non-empty.
 
 ### Access Control (AccessMessage)
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -64,7 +64,7 @@ This document is the authoritative reference for all data the mailing list servi
 
 ### Access Control (AccessMessage)
 
-Published to `lfx.update_access.groupsio_service` on create/update. Deleted via `lfx.delete_all_access.groupsio_service` on delete.
+Published to `lfx.fga-sync.update_access` on create/update. Deleted via `lfx.fga-sync.delete_access` on delete.
 
 | Field | Value |
 |---|---|
@@ -197,7 +197,7 @@ Published to `lfx.update_access.groupsio_service` on create/update. Deleted via 
 
 ### Access Control (AccessMessage)
 
-Published to `lfx.update_access.groupsio_mailing_list` on create/update. Deleted via `lfx.delete_all_access.groupsio_mailing_list` on delete.
+Published to `lfx.fga-sync.update_access` on create/update. Deleted via `lfx.fga-sync.delete_access` on delete.
 
 | Field | Value |
 |---|---|
@@ -351,10 +351,10 @@ This allows the member and artifact handlers to resolve the mailing list UID fro
 ### Access Control (AccessMessage)
 
 When a member has a non-empty `username`, the handler also publishes an FGA membership message:
-- **Put member:** `lfx.put_member.groupsio_mailing_list` on create/update
-- **Remove member:** `lfx.remove_member.groupsio_mailing_list` on delete
+- **Put member:** `lfx.fga-sync.member_put` on create/update
+- **Remove member:** `lfx.fga-sync.member_remove` on delete
 
-The message payload is `{ uid, username, mailing_list_uid }`.
+The message is a `GenericFGAMessage` with `object_type: groupsio_mailing_list`, `operation: member_put` / `member_remove`, and a `FGAMemberPutData` payload containing `uid` (the mailing list UID), `username` (principal), and `relations: ["member"]`.
 
 > **Username transform:** The `username` field in this FGA payload is **not** the raw Groups.io/LFID username. It is the principal value derived via `principal.FromUsername(member.Username)`, which produces an Auth0-style subject (e.g. `auth0|...`). Downstream FGA consumers should expect this format.
 
@@ -454,4 +454,4 @@ Artifacts use a typed `IndexingConfig` (no server-side enrichers). No FGA `Acces
 |---|---|
 | `project:{project_uid}` | Only when `project_uid` is set |
 | `committee:{committee_uid}` | Only when `committee_uid` is set |
-| `groupsio_mailing_list:{group_id}` | Always set (group_id is required) |
+| `groupsio_mailing_list:{group_id}` | Always set (numeric Groups.io group ID — the artifact model does not carry a mailing list UID) |

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -376,6 +376,7 @@ The message payload is `{ uid, username, mailing_list_uid }`.
 | Ref | Condition |
 |---|---|
 | `groupsio_mailing_list:{mailing_list_uid}` | Always set |
+| `project:{project_uid}` | Only when `project_uid` is set |
 
 ---
 

--- a/internal/domain/model/grpsio_member.go
+++ b/internal/domain/model/grpsio_member.go
@@ -113,6 +113,9 @@ func (m *GrpsIOMember) ParentRefs() []string {
 	if m.MailingListUID != "" {
 		refs = append(refs, fmt.Sprintf("groupsio_mailing_list:%s", m.MailingListUID))
 	}
+	if m.ProjectUID != "" {
+		refs = append(refs, fmt.Sprintf("project:%s", m.ProjectUID))
+	}
 	return refs
 }
 

--- a/internal/domain/model/grpsio_member.go
+++ b/internal/domain/model/grpsio_member.go
@@ -51,6 +51,10 @@ type GrpsIOMember struct {
 	LastReviewedAt *string `json:"last_reviewed_at"` // Nullable timestamp
 	LastReviewedBy *string `json:"last_reviewed_by"` // Nullable user ID
 
+	// Project association (inherited from the parent mailing list)
+	ProjectUID  string `json:"project_uid,omitempty"`
+	ProjectSlug string `json:"project_slug,omitempty"`
+
 	// Timestamps
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
@@ -88,6 +92,11 @@ func (m *GrpsIOMember) Tags() []string {
 
 	if m.Status != "" {
 		tag := fmt.Sprintf("status:%s", m.Status)
+		tags = append(tags, tag)
+	}
+
+	if m.ProjectUID != "" {
+		tag := fmt.Sprintf("project_uid:%s", m.ProjectUID)
 		tags = append(tags, tag)
 	}
 

--- a/internal/domain/model/message.go
+++ b/internal/domain/model/message.go
@@ -92,17 +92,33 @@ func (g *IndexerMessage) BuildWithIndexingConfig(ctx context.Context, input any,
 	return msg, nil
 }
 
-// AccessMessage is the schema for the data in the message sent to the fga-sync service
-// These are the fields that the fga-sync service needs in order to update the OpenFGA permissions
-type AccessMessage struct {
+// GenericFGAMessage is the envelope for all FGA sync operations.
+// It uses the generic, resource-agnostic FGA sync handlers.
+type GenericFGAMessage struct {
+	ObjectType string `json:"object_type"` // Resource type, e.g. "groupsio_service"
+	Operation  string `json:"operation"`   // Operation name, e.g. "update_access"
+	Data       any    `json:"data"`        // Operation-specific payload
+}
+
+// FGAUpdateAccessData is the data payload for update_access operations.
+// This is a full sync — any relations not listed (and not excluded) will be removed.
+type FGAUpdateAccessData struct {
+	UID              string              `json:"uid"`
+	Public           bool                `json:"public"`
+	Relations        map[string][]string `json:"relations,omitempty"`
+	References       map[string][]string `json:"references,omitempty"`
+	ExcludeRelations []string            `json:"exclude_relations,omitempty"`
+}
+
+// FGADeleteAccessData is the data payload for delete_access operations.
+type FGADeleteAccessData struct {
 	UID string `json:"uid"`
-	// ObjectType is the type of the object that the message is about, e.g. "groupsio_service"
-	ObjectType string `json:"object_type"`
-	// Public is the public flag for the object
-	Public bool `json:"public"`
-	// Relations is reserved for future use and is intentionally left empty
-	Relations map[string][]string `json:"relations"`
-	// References are used to store the references of the object,
-	// e.g. "project" and its value is the project UID for inheritance
-	References map[string][]string `json:"references"`
+}
+
+// FGAMemberPutData is the data payload for member_put and member_remove operations.
+type FGAMemberPutData struct {
+	UID                   string   `json:"uid"`
+	Username              string   `json:"username"`
+	Relations             []string `json:"relations"`
+	MutuallyExclusiveWith []string `json:"mutually_exclusive_with,omitempty"`
 }

--- a/internal/domain/model/message_test.go
+++ b/internal/domain/model/message_test.go
@@ -253,30 +253,35 @@ func TestMessageAction_Constants(t *testing.T) {
 	assert.Equal(t, MessageAction("deleted"), ActionDeleted)
 }
 
-func TestAccessMessage_Struct(t *testing.T) {
-	// Test that AccessMessage struct can be properly marshaled/unmarshaled
-	accessMsg := AccessMessage{
-		UID:        "access-123",
+func TestGenericFGAMessage_Struct(t *testing.T) {
+	// Test that GenericFGAMessage and FGAUpdateAccessData can be properly marshaled/unmarshaled
+	accessData := FGAUpdateAccessData{
+		UID:    "access-123",
+		Public: true,
+		Relations: map[string][]string{
+			"writer": {"user123"},
+		},
+		References: map[string][]string{
+			"project": {"project-456"},
+		},
+	}
+	msg := GenericFGAMessage{
 		ObjectType: constants.ObjectTypeGroupsIOService,
-		Public:     true,
-		Relations:  map[string][]string{"admin": {"user123"}},
-		References: map[string][]string{"project": {"project-456"}},
+		Operation:  "update_access",
+		Data:       accessData,
 	}
 
 	// Test JSON marshaling
-	data, err := json.Marshal(accessMsg)
+	data, err := json.Marshal(msg)
 	require.NoError(t, err)
 
-	// Test JSON unmarshaling
-	var unmarshaled AccessMessage
+	// Test JSON unmarshaling of the envelope
+	var unmarshaled GenericFGAMessage
 	err = json.Unmarshal(data, &unmarshaled)
 	require.NoError(t, err)
 
-	assert.Equal(t, accessMsg.UID, unmarshaled.UID)
-	assert.Equal(t, accessMsg.ObjectType, unmarshaled.ObjectType)
-	assert.Equal(t, accessMsg.Public, unmarshaled.Public)
-	assert.Equal(t, accessMsg.Relations, unmarshaled.Relations)
-	assert.Equal(t, accessMsg.References, unmarshaled.References)
+	assert.Equal(t, msg.ObjectType, unmarshaled.ObjectType)
+	assert.Equal(t, msg.Operation, unmarshaled.Operation)
 }
 
 // Benchmark for Build method with realistic data

--- a/internal/domain/model/message_test.go
+++ b/internal/domain/model/message_test.go
@@ -282,6 +282,20 @@ func TestGenericFGAMessage_Struct(t *testing.T) {
 
 	assert.Equal(t, msg.ObjectType, unmarshaled.ObjectType)
 	assert.Equal(t, msg.Operation, unmarshaled.Operation)
+
+	// Data is decoded as map[string]any when unmarshaling into GenericFGAMessage
+	dataMap, ok := unmarshaled.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "access-123", dataMap["uid"])
+	assert.Equal(t, true, dataMap["public"])
+
+	relationsMap, ok := dataMap["relations"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"user123"}, relationsMap["writer"])
+
+	referencesMap, ok := dataMap["references"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"project-456"}, referencesMap["project"])
 }
 
 // Benchmark for Build method with realistic data

--- a/internal/domain/port/project_lookup.go
+++ b/internal/domain/port/project_lookup.go
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package port
+
+import "context"
+
+// ProjectLookup fetches project attributes from the project service via NATS.
+type ProjectLookup interface {
+	// GetProjectSlug returns the URL slug for the given project UID.
+	// Returns an error on transient failures (e.g. NATS timeout); returns an
+	// empty string when the project exists but has no slug assigned.
+	GetProjectSlug(ctx context.Context, projectUID string) (string, error)
+}

--- a/internal/infrastructure/mock/project_lookup.go
+++ b/internal/infrastructure/mock/project_lookup.go
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package mock
+
+import (
+	"context"
+
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
+)
+
+// FakeProjectLookup is a test double for port.ProjectLookup.
+// Pre-populate Slugs with projectUID → slug entries as needed.
+// Set Err to simulate a transient failure.
+type FakeProjectLookup struct {
+	Slugs map[string]string
+	Err   error
+}
+
+var _ port.ProjectLookup = (*FakeProjectLookup)(nil)
+
+// NewFakeProjectLookup returns a FakeProjectLookup with an empty slug map.
+func NewFakeProjectLookup() *FakeProjectLookup {
+	return &FakeProjectLookup{Slugs: make(map[string]string)}
+}
+
+// GetProjectSlug returns the pre-configured slug for projectUID, or an empty
+// string if no entry is set (matching the real implementation's behaviour for
+// projects without a slug).
+func (f *FakeProjectLookup) GetProjectSlug(_ context.Context, projectUID string) (string, error) {
+	if f.Err != nil {
+		return "", f.Err
+	}
+	return f.Slugs[projectUID], nil
+}

--- a/internal/infrastructure/nats/project_lookup.go
+++ b/internal/infrastructure/nats/project_lookup.go
@@ -1,0 +1,53 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
+	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	projectGetSlugSubject    = "lfx.projects-api.get_slug"
+	projectLookupTimeout     = 5 * time.Second
+)
+
+// natsProjectLookup implements port.ProjectLookup using NATS request/reply
+// against the project service's lfx.projects-api.get_slug subject.
+type natsProjectLookup struct {
+	conn    *nats.Conn
+	timeout time.Duration
+}
+
+// GetProjectSlug returns the URL slug for the given project UID.
+func (p *natsProjectLookup) GetProjectSlug(ctx context.Context, projectUID string) (string, error) {
+	if projectUID == "" {
+		return "", nil
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	msg, err := p.conn.RequestWithContext(reqCtx, projectGetSlugSubject, []byte(projectUID))
+	if err != nil {
+		if err == context.DeadlineExceeded || err == nats.ErrTimeout {
+			return "", errs.NewServiceUnavailable("project slug lookup timed out", err)
+		}
+		return "", errs.NewServiceUnavailable("project slug lookup failed", err)
+	}
+
+	return string(msg.Data), nil
+}
+
+// NewNATSProjectLookup creates a ProjectLookup backed by the given NATSClient.
+func NewNATSProjectLookup(client *NATSClient) port.ProjectLookup {
+	return &natsProjectLookup{
+		conn:    client.conn,
+		timeout: projectLookupTimeout,
+	}
+}

--- a/internal/infrastructure/nats/project_lookup.go
+++ b/internal/infrastructure/nats/project_lookup.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
 	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
 	"github.com/nats-io/nats.go"
 )
 
 const (
-	projectGetSlugSubject    = "lfx.projects-api.get_slug"
-	projectLookupTimeout     = 5 * time.Second
+	projectLookupTimeout = 5 * time.Second
 )
 
 // natsProjectLookup implements port.ProjectLookup using NATS request/reply
@@ -33,7 +33,7 @@ func (p *natsProjectLookup) GetProjectSlug(ctx context.Context, projectUID strin
 	reqCtx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 
-	msg, err := p.conn.RequestWithContext(reqCtx, projectGetSlugSubject, []byte(projectUID))
+	msg, err := p.conn.RequestWithContext(reqCtx, constants.ProjectGetSlugSubject, []byte(projectUID))
 	if err != nil {
 		if err == context.DeadlineExceeded || err == nats.ErrTimeout {
 			return "", errs.NewServiceUnavailable("project slug lookup timed out", err)

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -63,12 +63,16 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 	}
 
 	if member.Username != "" {
-		accessMsg := &groupsioMailingListMemberStub{
-			UID:            uid,
-			Username:       principal.FromUsername(member.Username),
-			MailingListUID: mailingListUID,
+		accessMsg := model.GenericFGAMessage{
+			ObjectType: constants.ObjectTypeGroupsIOMailingList,
+			Operation:  "member_put",
+			Data: model.FGAMemberPutData{
+				UID:       mailingListUID,
+				Username:  principal.FromUsername(member.Username),
+				Relations: []string{constants.RelationMember},
+			},
 		}
-		if err := publisher.Access(ctx, constants.PutMemberGroupsIOMailingListSubject, accessMsg); err != nil {
+		if err := publisher.Access(ctx, constants.FGASyncMemberPutSubject, accessMsg); err != nil {
 			slog.WarnContext(ctx, "failed to publish member FGA put message", "uid", uid, "error", err)
 		}
 	}
@@ -114,12 +118,16 @@ func HandleDataStreamMemberDelete(ctx context.Context, uid string, publisher por
 
 	_, username, mailingListUID := parseMemberMappingValue(storedValue)
 	if username != "" {
-		accessMsg := &groupsioMailingListMemberStub{
-			UID:            uid,
-			Username:       principal.FromUsername(username),
-			MailingListUID: mailingListUID,
+		accessMsg := model.GenericFGAMessage{
+			ObjectType: constants.ObjectTypeGroupsIOMailingList,
+			Operation:  "member_remove",
+			Data: model.FGAMemberPutData{
+				UID:       mailingListUID,
+				Username:  principal.FromUsername(username),
+				Relations: []string{},
+			},
 		}
-		if err := publisher.Access(ctx, constants.RemoveMemberGroupsIOMailingListSubject, accessMsg); err != nil {
+		if err := publisher.Access(ctx, constants.FGASyncMemberRemoveSubject, accessMsg); err != nil {
 			slog.WarnContext(ctx, "failed to publish member FGA remove message", "uid", uid, "error", err)
 		}
 	}

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -39,6 +39,22 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 		return true // NAK — retry with backoff
 	}
 
+	// Resolve project UID and slug from the subgroup's project mapping written by the subgroup handler.
+	// NAK if absent — the subgroup must be fully processed (including slug lookup) before the member.
+	projectKey := fmt.Sprintf("%s.%s", constants.KVMappingPrefixSubgroupProject, mailingListUID)
+	projectMapping, ok := mappings.GetMappingValue(ctx, projectKey)
+	if !ok {
+		slog.WarnContext(ctx, "project mapping not yet available, NAKing member for retry",
+			"uid", uid, "mailing_list_uid", mailingListUID)
+		return true // NAK — retry with backoff
+	}
+	var projectUID, projectSlug string
+	if parts := strings.SplitN(projectMapping, "|", 2); len(parts) == 2 {
+		projectUID, projectSlug = parts[0], parts[1]
+	} else {
+		projectUID = projectMapping
+	}
+
 	mKey := fmt.Sprintf("%s.%s", constants.KVMappingPrefixMember, uid)
 
 	if mappings.IsTombstoned(ctx, mKey) {
@@ -48,7 +64,7 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 
 	action := mappings.ResolveAction(ctx, mKey)
 
-	member := transformV1ToGrpsIOMember(uid, mailingListUID, data)
+	member := transformV1ToGrpsIOMember(uid, mailingListUID, projectUID, projectSlug, data)
 
 	msg := &model.IndexerMessage{Action: action, Tags: member.Tags()}
 	built, err := msg.Build(ctx, member)
@@ -140,12 +156,15 @@ func HandleDataStreamMemberDelete(ctx context.Context, uid string, publisher por
 
 // transformV1ToGrpsIOMember maps v1 DynamoDB fields to the GrpsIOMember domain model.
 // mailingListUID is resolved from the reverse group_id index before calling this function.
-func transformV1ToGrpsIOMember(uid, mailingListUID string, data map[string]any) *model.GrpsIOMember {
+// projectUID and projectSlug are resolved from the subgroup's project mapping.
+func transformV1ToGrpsIOMember(uid, mailingListUID, projectUID, projectSlug string, data map[string]any) *model.GrpsIOMember {
 	firstName, lastName := splitFullName(mapconv.StringVal(data, "full_name"))
 
 	member := &model.GrpsIOMember{
 		UID:               uid,
 		MailingListUID:    mailingListUID,
+		ProjectUID:        projectUID,
+		ProjectSlug:       projectSlug,
 		MemberID:          mapconv.Int64Ptr(data, "member_id"),
 		GroupID:           mapconv.Int64Ptr(data, "group_id"),
 		UserID:            mapconv.StringVal(data, "user_id"),

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -121,7 +121,64 @@ func TestHandleDataStreamMemberDelete_HappyPath_ACKAndTombstones(t *testing.T) {
 	assert.False(t, nak)
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOMemberSubject, pub.IndexerCalls[0].Subject)
-	assert.Empty(t, pub.AccessCalls, "member delete should not publish access message")
+	assert.Empty(t, pub.AccessCalls, "member delete should not publish access message when no username in mapping")
+
+	assert.True(t, m.IsTombstoned(ctx, mKey))
+}
+
+func TestHandleDataStreamMemberUpdate_WithUsername_PublishesMemberPut(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberUpdate(context.Background(), "mem-1",
+		map[string]any{
+			"group_id":  float64(42),
+			"username":  "alice@example.com",
+			"full_name": "Alice Smith",
+		},
+		pub, m)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	assert.Len(t, pub.AccessCalls, 1)
+	assert.Equal(t, constants.FGASyncMemberPutSubject, pub.AccessCalls[0].Subject)
+
+	msg, ok := pub.AccessCalls[0].Message.(model.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, constants.ObjectTypeGroupsIOMailingList, msg.ObjectType)
+	assert.Equal(t, "member_put", msg.Operation)
+
+	data, ok := msg.Data.(model.FGAMemberPutData)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-1", data.UID)
+	assert.Equal(t, []string{constants.RelationMember}, data.Relations)
+}
+
+func TestHandleDataStreamMemberDelete_WithUsername_PublishesMemberRemove(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	// Store mapping in uid|username|mailingListUID format
+	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-1")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberDelete(ctx, "mem-1", pub, m)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	assert.Len(t, pub.AccessCalls, 1)
+	assert.Equal(t, constants.FGASyncMemberRemoveSubject, pub.AccessCalls[0].Subject)
+
+	msg, ok := pub.AccessCalls[0].Message.(model.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, constants.ObjectTypeGroupsIOMailingList, msg.ObjectType)
+	assert.Equal(t, "member_remove", msg.Operation)
+
+	data, ok := msg.Data.(model.FGAMemberPutData)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-1", data.UID)
+	assert.Empty(t, data.Relations)
 
 	assert.True(t, m.IsTombstoned(ctx, mKey))
 }

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// setProjectMapping is a helper that writes the groupsio-subgroup-project mapping
+// for the given mailingListUID into the fake mapping store.
+func setProjectMapping(m *mock.FakeMappingStore, mailingListUID, projectUID, projectSlug string) {
+	key := fmt.Sprintf("%s.%s", constants.KVMappingPrefixSubgroupProject, mailingListUID)
+	m.Set(key, projectUID+"|"+projectSlug)
+}
+
 // --- HandleDataStreamMemberUpdate ---
 
 func TestHandleDataStreamMemberUpdate_MissingGroupID_ACK(t *testing.T) {
@@ -31,10 +38,22 @@ func TestHandleDataStreamMemberUpdate_ParentSubgroupAbsent_NAK(t *testing.T) {
 	assert.True(t, nak, "absent subgroup mapping should NAK for retry")
 }
 
+func TestHandleDataStreamMemberUpdate_ProjectMappingAbsent_NAK(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	// project mapping deliberately absent
+
+	nak := HandleDataStreamMemberUpdate(context.Background(), "mem-1",
+		map[string]any{"group_id": float64(42)},
+		&mock.SpyMessagePublisher{}, m)
+	assert.True(t, nak, "absent project mapping should NAK for retry")
+}
+
 func TestHandleDataStreamMemberUpdate_Tombstoned_ACK(t *testing.T) {
 	m := mock.NewFakeMappingStore()
 	ctx := context.Background()
 	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
 	_ = m.PutTombstone(ctx, fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember))
 
 	pub := &mock.SpyMessagePublisher{}
@@ -49,6 +68,7 @@ func TestHandleDataStreamMemberUpdate_Tombstoned_ACK(t *testing.T) {
 func TestHandleDataStreamMemberUpdate_HappyPath_ACKAndPublishesAndWritesMapping(t *testing.T) {
 	m := mock.NewFakeMappingStore()
 	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
 
 	pub := &mock.SpyMessagePublisher{}
 	nak := HandleDataStreamMemberUpdate(context.Background(), "mem-1",
@@ -70,9 +90,33 @@ func TestHandleDataStreamMemberUpdate_HappyPath_ACKAndPublishesAndWritesMapping(
 	assert.True(t, present, "forward mapping should be written after successful processing")
 }
 
+func TestHandleDataStreamMemberUpdate_ProjectFieldsPopulated(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid-123", "my-project-slug")
+
+	pub := &mock.SpyMessagePublisher{}
+	HandleDataStreamMemberUpdate(context.Background(), "mem-1",
+		map[string]any{
+			"group_id": float64(42),
+			"email":    "alice@example.com",
+		},
+		pub, m)
+
+	assert.Len(t, pub.IndexerCalls, 1)
+	indexerMsg, ok := pub.IndexerCalls[0].Message.(*model.IndexerMessage)
+	assert.True(t, ok, "indexer message should be *model.IndexerMessage")
+	// Build marshals the member to JSON then stores it as map[string]any
+	memberData, ok := indexerMsg.Data.(map[string]any)
+	assert.True(t, ok, "indexer message data should be map[string]any")
+	assert.Equal(t, "proj-uid-123", memberData["project_uid"])
+	assert.Equal(t, "my-project-slug", memberData["project_slug"])
+}
+
 func TestHandleDataStreamMemberUpdate_CreateVsUpdate_Action(t *testing.T) {
 	m := mock.NewFakeMappingStore()
 	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
 
 	data := func() map[string]any { return map[string]any{"group_id": float64(42)} }
 	ctx := context.Background()
@@ -129,6 +173,7 @@ func TestHandleDataStreamMemberDelete_HappyPath_ACKAndTombstones(t *testing.T) {
 func TestHandleDataStreamMemberUpdate_WithUsername_PublishesMemberPut(t *testing.T) {
 	m := mock.NewFakeMappingStore()
 	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
 
 	pub := &mock.SpyMessagePublisher{}
 	nak := HandleDataStreamMemberUpdate(context.Background(), "mem-1",

--- a/internal/service/datastream_service_handler.go
+++ b/internal/service/datastream_service_handler.go
@@ -65,24 +65,31 @@ func HandleDataStreamServiceUpdate(ctx context.Context, uid string, data map[str
 		}
 	}
 
-	references := map[string][]string{
-		constants.RelationProject: {svc.ProjectUID},
-	}
+	relations := map[string][]string{}
 	if settings != nil {
 		if writers := userInfoUsernames(settings.Writers); len(writers) > 0 {
-			references[constants.RelationWriter] = writers
+			relations[constants.RelationWriter] = writers
 		}
 		if auditors := userInfoUsernames(settings.Auditors); len(auditors) > 0 {
-			references[constants.RelationAuditor] = auditors
+			relations[constants.RelationAuditor] = auditors
 		}
 	}
-	accessMsg := &model.AccessMessage{
-		UID:        uid,
-		ObjectType: constants.ObjectTypeGroupsIOService,
-		Public:     svc.Public,
-		References: references,
+	accessData := model.FGAUpdateAccessData{
+		UID:    uid,
+		Public: svc.Public,
+		References: map[string][]string{
+			constants.RelationProject: {svc.ProjectUID},
+		},
 	}
-	if err := publisher.Access(ctx, constants.UpdateAccessGroupsIOServiceSubject, accessMsg); err != nil {
+	if len(relations) > 0 {
+		accessData.Relations = relations
+	}
+	accessMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOService,
+		Operation:  "update_access",
+		Data:       accessData,
+	}
+	if err := publisher.Access(ctx, constants.FGASyncUpdateAccessSubject, accessMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish service access message", "uid", uid, "error", err)
 	}
 
@@ -114,7 +121,12 @@ func HandleDataStreamServiceDelete(ctx context.Context, uid string, publisher po
 		return pkgerrors.IsTransient(err)
 	}
 
-	if err := publisher.Access(ctx, constants.DeleteAllAccessGroupsIOServiceSubject, uid); err != nil {
+	deleteMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOService,
+		Operation:  "delete_access",
+		Data:       model.FGADeleteAccessData{UID: uid},
+	}
+	if err := publisher.Access(ctx, constants.FGASyncDeleteAccessSubject, deleteMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish service delete access message", "uid", uid, "error", err)
 	}
 

--- a/internal/service/datastream_service_handler_test.go
+++ b/internal/service/datastream_service_handler_test.go
@@ -45,7 +45,7 @@ func TestHandleDataStreamServiceUpdate_HappyPath_ACKAndPublishes(t *testing.T) {
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOServiceSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.UpdateAccessGroupsIOServiceSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncUpdateAccessSubject, pub.AccessCalls[0].Subject)
 
 	_, present := m.GetMappingValue(context.Background(),
 		fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService))
@@ -86,7 +86,7 @@ func TestHandleDataStreamServiceDelete_HappyPath_ACKAndTombstones(t *testing.T) 
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOServiceSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.DeleteAllAccessGroupsIOServiceSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncDeleteAccessSubject, pub.AccessCalls[0].Subject)
 
 	assert.True(t, m.IsTombstoned(context.Background(),
 		fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService)))

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -18,8 +18,8 @@ import (
 
 // HandleDataStreamSubgroupUpdate transforms the v1 payload into a GrpsIOMailingList and publishes
 // indexer + access control messages. Returns true to NAK when the parent service mapping
-// is absent (ordering guarantee) or on transient errors.
-func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[string]any, publisher port.MessagePublisher, mappings port.MappingReaderWriter) bool {
+// is absent (ordering guarantee), the project slug lookup fails (transient), or on transient errors.
+func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[string]any, publisher port.MessagePublisher, mappings port.MappingReaderWriter, projectLookup port.ProjectLookup) bool {
 	// Resolve v1 project SFID → v2 project UID via the shared project.sfid.{sfid} mapping
 	// written by lfx-v1-sync-helper. NAK if the project hasn't been processed yet.
 	projectSFID := mapconv.StringVal(data, "project_id")
@@ -34,6 +34,15 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 		return true // NAK — retry with backoff
 	}
 	data["project_id"] = projectUID
+
+	// Look up project slug from the project service. NAK on transient errors so the
+	// subgroup is retried once the project service is available.
+	projectSlug, err := projectLookup.GetProjectSlug(ctx, projectUID)
+	if err != nil {
+		slog.WarnContext(ctx, "project slug lookup failed, NAKing subgroup for retry",
+			"uid", uid, "project_uid", projectUID, "error", err)
+		return true // NAK — retry with backoff
+	}
 
 	// Resolve optional v1 committee SFID → v2 committee UID. NAK if the committee
 	// has been specified but hasn't been synced yet (ordering guarantee).
@@ -146,6 +155,13 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 		if err := mappings.PutMapping(ctx, gidKey, uid); err != nil {
 			slog.ErrorContext(ctx, "failed to put mapping key", "mapping_key", gidKey, "error", err)
 		}
+	}
+
+	// Store project mapping: project_uid and project_slug for the member handler.
+	// Value format: "{project_uid}|{project_slug}"
+	projectKey := fmt.Sprintf("%s.%s", constants.KVMappingPrefixSubgroupProject, uid)
+	if err := mappings.PutMapping(ctx, projectKey, projectUID+"|"+projectSlug); err != nil {
+		slog.ErrorContext(ctx, "failed to put project mapping key", "mapping_key", projectKey, "error", err)
 	}
 
 	return false

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -36,15 +36,6 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 	}
 	data["project_id"] = projectUID
 
-	// Look up project slug from the project service. NAK on transient errors so the
-	// subgroup is retried once the project service is available.
-	projectSlug, err := projectLookup.GetProjectSlug(ctx, projectUID)
-	if err != nil {
-		slog.WarnContext(ctx, "project slug lookup failed, NAKing subgroup for retry",
-			"uid", uid, "project_uid", projectUID, "error", err)
-		return true // NAK — retry with backoff
-	}
-
 	// Resolve optional v1 committee SFID → v2 committee UID. NAK if the committee
 	// has been specified but hasn't been synced yet (ordering guarantee).
 	if committeeSFID := mapconv.StringVal(data, "committee"); committeeSFID != "" {
@@ -70,6 +61,16 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 	if !mappings.IsMappingPresent(ctx, serviceKey) {
 		slog.WarnContext(ctx, "parent service not yet processed, NAKing subgroup for retry",
 			"uid", uid, "service_uid", list.ServiceUID)
+		return true // NAK — retry with backoff
+	}
+
+	// Look up project slug from the project service. NAK on transient errors so the
+	// subgroup is retried once the project service is available. This is done after
+	// dependency checks to avoid unnecessary RPCs when the record will NAK anyway.
+	projectSlug, err := projectLookup.GetProjectSlug(ctx, projectUID)
+	if err != nil {
+		slog.WarnContext(ctx, "project slug lookup failed, NAKing subgroup for retry",
+			"uid", uid, "project_uid", projectUID, "error", err)
 		return true // NAK — retry with backoff
 	}
 
@@ -186,9 +187,11 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 
 	// Store project mapping: project_uid and project_slug for the member handler.
 	// Value format: "{project_uid}|{project_slug}"
+	// NAK on failure — member events depend on this mapping to resolve project fields.
 	projectKey := fmt.Sprintf("%s.%s", constants.KVMappingPrefixSubgroupProject, uid)
 	if err := mappings.PutMapping(ctx, projectKey, projectUID+"|"+projectSlug); err != nil {
-		slog.ErrorContext(ctx, "failed to put project mapping key", "mapping_key", projectKey, "error", err)
+		slog.ErrorContext(ctx, "failed to put project mapping key, NAKing for retry", "mapping_key", projectKey, "error", err)
+		return pkgerrors.IsTransient(err)
 	}
 
 	return false

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -16,16 +16,6 @@ import (
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/mapconv"
 )
 
-// groupsioMailingListMemberStub represents the minimal data needed for member access control
-type groupsioMailingListMemberStub struct {
-	// UID is the mailing list member ID.
-	UID string `json:"uid"`
-	// Username is the username (i.e. LFID) of the member. This is the identity of the user object in FGA.
-	Username string `json:"username"`
-	// MailingListUID is the mailing list ID for the mailing list the member belongs to.
-	MailingListUID string `json:"mailing_list_uid"`
-}
-
 // HandleDataStreamSubgroupUpdate transforms the v1 payload into a GrpsIOMailingList and publishes
 // indexer + access control messages. Returns true to NAK when the parent service mapping
 // is absent (ordering guarantee) or on transient errors.
@@ -118,21 +108,31 @@ func HandleDataStreamSubgroupUpdate(ctx context.Context, uid string, data map[st
 			references[constants.RelationCommittee] = append(references[constants.RelationCommittee], committee.UID)
 		}
 	}
+	relations := map[string][]string{}
 	if settings != nil {
 		if writers := userInfoUsernames(settings.Writers); len(writers) > 0 {
-			references[constants.RelationWriter] = writers
+			relations[constants.RelationWriter] = writers
 		}
 		if auditors := userInfoUsernames(settings.Auditors); len(auditors) > 0 {
-			references[constants.RelationAuditor] = auditors
+			relations[constants.RelationAuditor] = auditors
 		}
 	}
-	accessMsg := &model.AccessMessage{
+	accessData := model.FGAUpdateAccessData{
 		UID:        uid,
-		ObjectType: constants.ObjectTypeGroupsIOMailingList,
 		Public:     list.Public,
 		References: references,
+		// member relations are managed separately via member_put and must not be overwritten here
+		ExcludeRelations: []string{constants.RelationMember},
 	}
-	if err := publisher.Access(ctx, constants.UpdateAccessGroupsIOMailingListSubject, accessMsg); err != nil {
+	if len(relations) > 0 {
+		accessData.Relations = relations
+	}
+	accessMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOMailingList,
+		Operation:  "update_access",
+		Data:       accessData,
+	}
+	if err := publisher.Access(ctx, constants.FGASyncUpdateAccessSubject, accessMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish subgroup access message", "uid", uid, "error", err)
 	}
 
@@ -181,7 +181,12 @@ func HandleDataStreamSubgroupDelete(ctx context.Context, uid string, publisher p
 		return pkgerrors.IsTransient(err)
 	}
 
-	if err := publisher.Access(ctx, constants.DeleteAllAccessGroupsIOMailingListSubject, uid); err != nil {
+	deleteMsg := model.GenericFGAMessage{
+		ObjectType: constants.ObjectTypeGroupsIOMailingList,
+		Operation:  "delete_access",
+		Data:       model.FGADeleteAccessData{UID: uid},
+	}
+	if err := publisher.Access(ctx, constants.FGASyncDeleteAccessSubject, deleteMsg); err != nil {
 		slog.WarnContext(ctx, "failed to publish subgroup delete access message", "uid", uid, "error", err)
 	}
 

--- a/internal/service/datastream_subgroup_handler_test.go
+++ b/internal/service/datastream_subgroup_handler_test.go
@@ -75,7 +75,7 @@ func TestHandleDataStreamSubgroupUpdate_HappyPath_ACKAndPublishesAndWritesMappin
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOMailingListSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.UpdateAccessGroupsIOMailingListSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncUpdateAccessSubject, pub.AccessCalls[0].Subject)
 
 	_, present := m.GetMappingValue(context.Background(),
 		fmt.Sprintf("%s.sg-1", constants.KVMappingPrefixSubgroup))
@@ -142,7 +142,7 @@ func TestHandleDataStreamSubgroupDelete_HappyPath_ACKAndTombstones(t *testing.T)
 	assert.Len(t, pub.IndexerCalls, 1)
 	assert.Equal(t, constants.IndexGroupsIOMailingListSubject, pub.IndexerCalls[0].Subject)
 	assert.Len(t, pub.AccessCalls, 1)
-	assert.Equal(t, constants.DeleteAllAccessGroupsIOMailingListSubject, pub.AccessCalls[0].Subject)
+	assert.Equal(t, constants.FGASyncDeleteAccessSubject, pub.AccessCalls[0].Subject)
 
 	assert.True(t, m.IsTombstoned(context.Background(),
 		fmt.Sprintf("%s.sg-1", constants.KVMappingPrefixSubgroup)))

--- a/internal/service/datastream_subgroup_handler_test.go
+++ b/internal/service/datastream_subgroup_handler_test.go
@@ -16,15 +16,29 @@ import (
 func TestHandleDataStreamSubgroupUpdate_MissingProjectID_ACK(t *testing.T) {
 	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
 		map[string]any{},
-		&mock.SpyMessagePublisher{}, mock.NewFakeMappingStore())
+		&mock.SpyMessagePublisher{}, mock.NewFakeMappingStore(), mock.NewFakeProjectLookup())
 	assert.False(t, nak, "missing project_id should ACK")
 }
 
 func TestHandleDataStreamSubgroupUpdate_ProjectMappingAbsent_NAK(t *testing.T) {
 	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
 		map[string]any{"project_id": "sfid-proj"},
-		&mock.SpyMessagePublisher{}, mock.NewFakeMappingStore())
+		&mock.SpyMessagePublisher{}, mock.NewFakeMappingStore(), mock.NewFakeProjectLookup())
 	assert.True(t, nak, "unknown project mapping should NAK")
+}
+
+func TestHandleDataStreamSubgroupUpdate_ProjectSlugLookupFails_NAK(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	m.Set(fmt.Sprintf("%s.sfid-proj", constants.KVMappingPrefixProjectBySFID), "proj-uid")
+	m.Set(fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService), "svc-1")
+
+	pl := mock.NewFakeProjectLookup()
+	pl.Err = fmt.Errorf("project service unavailable")
+
+	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
+		map[string]any{"project_id": "sfid-proj", "parent_id": "svc-1"},
+		&mock.SpyMessagePublisher{}, m, pl)
+	assert.True(t, nak, "project slug lookup failure should NAK")
 }
 
 func TestHandleDataStreamSubgroupUpdate_CommitteeMappingAbsent_NAK(t *testing.T) {
@@ -32,13 +46,16 @@ func TestHandleDataStreamSubgroupUpdate_CommitteeMappingAbsent_NAK(t *testing.T)
 	m.Set(fmt.Sprintf("%s.sfid-proj", constants.KVMappingPrefixProjectBySFID), "proj-uid")
 	m.Set(fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService), "svc-1")
 
+	pl := mock.NewFakeProjectLookup()
+	pl.Slugs["proj-uid"] = "my-project"
+
 	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
 		map[string]any{
 			"project_id": "sfid-proj",
 			"parent_id":  "svc-1",
 			"committee":  "sfid-committee", // mapping absent
 		},
-		&mock.SpyMessagePublisher{}, m)
+		&mock.SpyMessagePublisher{}, m, pl)
 	assert.True(t, nak, "unknown committee mapping should NAK")
 }
 
@@ -47,12 +64,15 @@ func TestHandleDataStreamSubgroupUpdate_ParentServiceAbsent_NAK(t *testing.T) {
 	m.Set(fmt.Sprintf("%s.sfid-proj", constants.KVMappingPrefixProjectBySFID), "proj-uid")
 	// service mapping deliberately absent
 
+	pl := mock.NewFakeProjectLookup()
+	pl.Slugs["proj-uid"] = "my-project"
+
 	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
 		map[string]any{
 			"project_id": "sfid-proj",
 			"parent_id":  "svc-1",
 		},
-		&mock.SpyMessagePublisher{}, m)
+		&mock.SpyMessagePublisher{}, m, pl)
 	assert.True(t, nak, "absent parent service should NAK")
 }
 
@@ -60,6 +80,9 @@ func TestHandleDataStreamSubgroupUpdate_HappyPath_ACKAndPublishesAndWritesMappin
 	m := mock.NewFakeMappingStore()
 	m.Set(fmt.Sprintf("%s.sfid-proj", constants.KVMappingPrefixProjectBySFID), "proj-uid")
 	m.Set(fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService), "svc-1")
+
+	pl := mock.NewFakeProjectLookup()
+	pl.Slugs["proj-uid"] = "my-project"
 
 	pub := &mock.SpyMessagePublisher{}
 	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
@@ -69,7 +92,7 @@ func TestHandleDataStreamSubgroupUpdate_HappyPath_ACKAndPublishesAndWritesMappin
 			"group_id":   float64(42),
 			"group_name": "dev",
 		},
-		pub, m)
+		pub, m, pl)
 
 	assert.False(t, nak)
 	assert.Len(t, pub.IndexerCalls, 1)
@@ -85,6 +108,11 @@ func TestHandleDataStreamSubgroupUpdate_HappyPath_ACKAndPublishesAndWritesMappin
 		fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID))
 	assert.True(t, ok, "reverse group_id index should be written")
 	assert.Equal(t, "sg-1", rev)
+
+	projMapping, ok := m.GetMappingValue(context.Background(),
+		fmt.Sprintf("%s.sg-1", constants.KVMappingPrefixSubgroupProject))
+	assert.True(t, ok, "project mapping should be written")
+	assert.Equal(t, "proj-uid|my-project", projMapping)
 }
 
 func TestHandleDataStreamSubgroupUpdate_WithCommittee_ResolvesAndPublishes(t *testing.T) {
@@ -93,6 +121,9 @@ func TestHandleDataStreamSubgroupUpdate_WithCommittee_ResolvesAndPublishes(t *te
 	m.Set(fmt.Sprintf("%s.sfid-committee", constants.KVMappingPrefixCommitteeBySFID), "committee-uid")
 	m.Set(fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService), "svc-1")
 
+	pl := mock.NewFakeProjectLookup()
+	pl.Slugs["proj-uid"] = "my-project"
+
 	pub := &mock.SpyMessagePublisher{}
 	nak := HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
 		map[string]any{
@@ -100,7 +131,7 @@ func TestHandleDataStreamSubgroupUpdate_WithCommittee_ResolvesAndPublishes(t *te
 			"parent_id":  "svc-1",
 			"committee":  "sfid-committee",
 		},
-		pub, m)
+		pub, m, pl)
 
 	assert.False(t, nak)
 	assert.Len(t, pub.IndexerCalls, 1)
@@ -111,9 +142,12 @@ func TestHandleDataStreamSubgroupUpdate_NoGroupID_NoReverseIndex(t *testing.T) {
 	m.Set(fmt.Sprintf("%s.sfid-proj", constants.KVMappingPrefixProjectBySFID), "proj-uid")
 	m.Set(fmt.Sprintf("%s.svc-1", constants.KVMappingPrefixService), "svc-1")
 
+	pl := mock.NewFakeProjectLookup()
+	pl.Slugs["proj-uid"] = "my-project"
+
 	HandleDataStreamSubgroupUpdate(context.Background(), "sg-1",
 		map[string]any{"project_id": "sfid-proj", "parent_id": "svc-1"},
-		&mock.SpyMessagePublisher{}, m)
+		&mock.SpyMessagePublisher{}, m, pl)
 
 	_, ok := m.GetMappingValue(context.Background(),
 		fmt.Sprintf("%s.0", constants.KVMappingPrefixSubgroupByGroupID))

--- a/pkg/constants/storage.go
+++ b/pkg/constants/storage.go
@@ -71,6 +71,11 @@ const (
 	// KVMappingPrefixSubgroupByGroupID is the v1-mappings reverse index: Groups.io group_id → subgroup UID.
 	// Written by the subgroup handler so the member handler can resolve MailingListUID from group_id.
 	KVMappingPrefixSubgroupByGroupID = "groupsio-subgroup-gid"
+	// KVMappingPrefixSubgroupProject is the v1-mappings key that stores the project UID and slug for a
+	// subgroup (mailing list). Written by the subgroup handler; read by the member handler so that
+	// project_uid and project_slug can be included on indexed groupsio_member records.
+	// Value format: "{project_uid}|{project_slug}"
+	KVMappingPrefixSubgroupProject = "groupsio-subgroup-project"
 	// KVMappingPrefixArtifact is the v1-mappings key prefix for GroupsIO artifacts.
 	KVMappingPrefixArtifact = "groupsio-artifact"
 

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -13,15 +13,11 @@ const (
 	IndexGroupsIOMemberSubject               = "lfx.index.groupsio_member"
 	IndexGroupsIOArtifactSubject             = "lfx.index.groupsio_artifact"
 
-	// Access control subjects for OpenFGA integration
-	UpdateAccessGroupsIOServiceSubject    = "lfx.update_access.groupsio_service"
-	DeleteAllAccessGroupsIOServiceSubject = "lfx.delete_all_access.groupsio_service"
-
-	UpdateAccessGroupsIOMailingListSubject    = "lfx.update_access.groupsio_mailing_list"
-	DeleteAllAccessGroupsIOMailingListSubject = "lfx.delete_all_access.groupsio_mailing_list"
-
-	PutMemberGroupsIOMailingListSubject    = "lfx.put_member.groupsio_mailing_list"
-	RemoveMemberGroupsIOMailingListSubject = "lfx.remove_member.groupsio_mailing_list"
+	// Generic FGA sync subjects for OpenFGA integration
+	FGASyncUpdateAccessSubject = "lfx.fga-sync.update_access"
+	FGASyncDeleteAccessSubject = "lfx.fga-sync.delete_access"
+	FGASyncMemberPutSubject    = "lfx.fga-sync.member_put"
+	FGASyncMemberRemoveSubject = "lfx.fga-sync.member_remove"
 
 	// Committee event subjects from committee-api
 	CommitteeMemberCreatedSubject = "lfx.committee-api.committee_member.created"


### PR DESCRIPTION
## Summary

- Add `project_uid` and `project_slug` fields to the `groupsio_member` indexed record so the Persona Service can resolve the project for a given mailing list member without a secondary lookup
- Subgroup handler fetches the project slug from the project service via NATS request/reply (`lfx.projects-api.get_slug`) and caches `{project_uid}|{project_slug}` in a new KV mapping (`groupsio-subgroup-project.{subgroup_uid}`)
- Member handler reads that mapping (NAKing if absent for ordering guarantee) and sets `ProjectUID`/`ProjectSlug` on the indexed member record
- `Tags()` emits `project_uid:{value}` tag when set, surfaced via the member's `IndexingConfig.Tags`
- Includes merge of #49 — member handler now uses `BuildWithIndexingConfig` with full `IndexingConfig` (access/history check, parent refs, name aliases, sort name, fulltext)
- `docs/indexer-contract.md` updated with `project_uid`, `project_slug` schema rows and `project_uid:{value}` tag

> ⚠️ **Depends on #49** — that PR must be merged first since this branch includes it.

## Ticket

[LFXV2-1418](https://linuxfoundation.atlassian.net/browse/LFXV2-1418)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1418]: https://linuxfoundation.atlassian.net/browse/LFXV2-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ