### PR TITLE
fix: use groupsio_mailing_list for artifact access and history check objects

### DIFF
--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -446,9 +446,9 @@ Artifacts use a typed `IndexingConfig` (no server-side enrichers). No FGA `Acces
 |---|---|
 | `object_id` | `{artifact_id}` |
 | `public` | `false` (always) |
-| `access_check_object` | `groupsio_mailing_list:{parent_mailing_list_uid}` |
+| `access_check_object` | `groupsio_mailing_list:{mailing_list_uid}` |
 | `access_check_relation` | `viewer` |
-| `history_check_object` | `groupsio_mailing_list:{parent_mailing_list_uid}` |
+| `history_check_object` | `groupsio_mailing_list:{mailing_list_uid}` |
 | `history_check_relation` | `auditor` |
 
 ### Search Behavior

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -446,9 +446,9 @@ Artifacts use a typed `IndexingConfig` (no server-side enrichers). No FGA `Acces
 |---|---|
 | `object_id` | `{artifact_id}` |
 | `public` | `false` (always) |
-| `access_check_object` | `groupsio_artifact:{artifact_id}` |
+| `access_check_object` | `groupsio_mailing_list:{parent_mailing_list_uid}` |
 | `access_check_relation` | `viewer` |
-| `history_check_object` | `groupsio_artifact:{artifact_id}` |
+| `history_check_object` | `groupsio_mailing_list:{parent_mailing_list_uid}` |
 | `history_check_relation` | `auditor` |
 
 ### Search Behavior

--- a/internal/service/datastream_artifact_handler.go
+++ b/internal/service/datastream_artifact_handler.go
@@ -31,7 +31,7 @@ func HandleDataStreamArtifactUpdate(ctx context.Context, uid string, data map[st
 	}
 
 	gidKey := fmt.Sprintf("%s.%d", constants.KVMappingPrefixSubgroupByGroupID, *groupID)
-	_, ok := mappings.GetMappingValue(ctx, gidKey)
+	mailingListUID, ok := mappings.GetMappingValue(ctx, gidKey)
 	if !ok {
 		slog.WarnContext(ctx, "parent subgroup not yet processed, NAKing artifact for retry",
 			"uid", uid, "group_id", *groupID)
@@ -72,13 +72,13 @@ func HandleDataStreamArtifactUpdate(ctx context.Context, uid string, data map[st
 	artifact := transformV1ToGroupsIOArtifact(uid, data)
 
 	isPublic := false
-	groupRef := fmt.Sprintf("groupsio_artifact:%s", uid)
+	mailingListRef := fmt.Sprintf("groupsio_mailing_list:%s", mailingListUID)
 	indexingConfig := &indexertypes.IndexingConfig{
 		ObjectID:             uid,
 		Public:               &isPublic,
-		AccessCheckObject:    groupRef,
+		AccessCheckObject:    mailingListRef,
 		AccessCheckRelation:  "viewer",
-		HistoryCheckObject:   groupRef,
+		HistoryCheckObject:   mailingListRef,
 		HistoryCheckRelation: "auditor",
 		ParentRefs:           artifact.ParentRefs(),
 		NameAndAliases:       artifact.NameAndAliases(),

--- a/internal/service/datastream_artifact_handler_test.go
+++ b/internal/service/datastream_artifact_handler_test.go
@@ -1,0 +1,52 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/infrastructure/mock"
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleDataStreamArtifactUpdate_MissingGroupID_ACK(t *testing.T) {
+	nak := HandleDataStreamArtifactUpdate(context.Background(), "art-1",
+		map[string]any{},
+		&mock.SpyMessagePublisher{}, mock.NewFakeMappingStore())
+	assert.False(t, nak, "missing group_id should ACK (malformed data, no retry)")
+}
+
+func TestHandleDataStreamArtifactUpdate_ParentSubgroupAbsent_NAK(t *testing.T) {
+	nak := HandleDataStreamArtifactUpdate(context.Background(), "art-1",
+		map[string]any{"group_id": float64(42)},
+		&mock.SpyMessagePublisher{}, mock.NewFakeMappingStore())
+	assert.True(t, nak, "absent subgroup mapping should NAK for retry")
+}
+
+func TestHandleDataStreamArtifactUpdate_AccessCheckUsesMailingList(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "ml-uid-123")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamArtifactUpdate(context.Background(), "art-1",
+		map[string]any{"group_id": float64(42)},
+		pub, m)
+
+	assert.False(t, nak)
+	require.Len(t, pub.IndexerCalls, 1)
+
+	msg, ok := pub.IndexerCalls[0].Message.(*model.IndexerMessage)
+	require.True(t, ok, "published message should be *model.IndexerMessage")
+	require.NotNil(t, msg.IndexingConfig)
+
+	assert.Equal(t, "groupsio_mailing_list:ml-uid-123", msg.IndexingConfig.AccessCheckObject,
+		"access_check_object must reference the parent mailing list, not groupsio_artifact")
+	assert.Equal(t, "groupsio_mailing_list:ml-uid-123", msg.IndexingConfig.HistoryCheckObject,
+		"history_check_object must reference the parent mailing list, not groupsio_artifact")
+}


### PR DESCRIPTION
## Summary

- `groupsio_artifact` does not exist in the OpenFGA authorization model — the correct object type for access/history checks on artifacts is the parent `groupsio_mailing_list`
- Capture the subgroup UID already resolved from the `group_id` reverse index (previously discarded) and use `groupsio_mailing_list:{mailingListUID}` for both `access_check_object` and `history_check_object`
- Update `docs/indexer-contract.md` to reflect the correct values
- Add unit tests covering the bug scenario

## Test plan

- [x] `TestHandleDataStreamArtifactUpdate_MissingGroupID_ACK` — malformed data ACKs cleanly
- [x] `TestHandleDataStreamArtifactUpdate_ParentSubgroupAbsent_NAK` — NAKs for retry when parent not yet indexed
- [x] `TestHandleDataStreamArtifactUpdate_AccessCheckUsesMailingList` — asserts `access_check_object` and `history_check_object` are `groupsio_mailing_list:{parentUID}`
- [x] Full test suite passes (`make test`)

🤖 Generated with [Claude Code](https://claude.ai/code)