### PR TITLE
feat: exclude health endpoints from tracing

### DIFF
--- a/cmd/mailing-list-api/http.go
+++ b/cmd/mailing-list-api/http.go
@@ -80,7 +80,7 @@ func handleHTTPServer(ctx context.Context, host string, mailingListServiceEndpoi
 	handler = otelhttp.NewHandler(handler, "mailing-list-api",
 		otelhttp.WithFilter(func(r *http.Request) bool {
 			p := r.URL.Path
-			return p != "/healthz" && p != "/livez" && p != "/readyz"
+			return p != mailinglistservicesvr.LivezMailingListPath() && p != mailinglistservicesvr.ReadyzMailingListPath()
 		}),
 	)
 

--- a/cmd/mailing-list-api/http.go
+++ b/cmd/mailing-list-api/http.go
@@ -77,7 +77,12 @@ func handleHTTPServer(ctx context.Context, host string, mailingListServiceEndpoi
 		handler = debug.HTTP()(handler)
 	}
 	// Add OpenTelemetry HTTP instrumentation (outermost to capture full request lifecycle)
-	handler = otelhttp.NewHandler(handler, "mailing-list-api")
+	handler = otelhttp.NewHandler(handler, "mailing-list-api",
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			p := r.URL.Path
+			return p != "/healthz" && p != "/livez" && p != "/readyz"
+		}),
+	)
 
 	// Start HTTP server using default configuration, change the code to
 	// configure the server as required by your service.


### PR DESCRIPTION
## Summary

- Add `otelhttp.WithFilter` to `otelhttp.NewHandler` to skip span creation for `/healthz`, `/livez`, and `/readyz` Kubernetes probe endpoints
- Reduces high-volume, low-value trace noise from liveness/readiness probes

## Test plan

- [x] `go build ./...` passes

Issue: LFXV2-1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)