### PR TITLE
fix(otel): honor parent span sampling decisions

### DIFF
--- a/charts/lfx-v2-mailing-list-service/templates/deployment.yaml
+++ b/charts/lfx-v2-mailing-list-service/templates/deployment.yaml
@@ -76,19 +76,10 @@ spec:
             - name: OTEL_TRACES_EXPORTER
               value: {{ $otelTracesExporter | quote }}
             {{- end }}
-            {{- $otelTracesSampleRatio := .Values.app.otel.tracesSampleRatio | toString | trim }}
-            {{- if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLE_RATIO
-              value: {{ $otelTracesSampleRatio | quote }}
-            {{- end }}
             {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
             {{- if ne $otelTracesSampler "" }}
             - name: OTEL_TRACES_SAMPLER
               value: {{ $otelTracesSampler | quote }}
-            {{- if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLER_ARG
-              value: {{ $otelTracesSampleRatio | quote }}
-            {{- end }}
             {{- end }}
             {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}

--- a/charts/lfx-v2-mailing-list-service/templates/deployment.yaml
+++ b/charts/lfx-v2-mailing-list-service/templates/deployment.yaml
@@ -81,6 +81,11 @@ spec:
             - name: OTEL_TRACES_SAMPLER
               value: {{ $otelTracesSampler | quote }}
             {{- end }}
+            {{- $otelTracesSamplerArg := .Values.app.otel.tracesSamplerArg | toString | trim }}
+            {{- if ne $otelTracesSamplerArg "" }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ $otelTracesSamplerArg | quote }}
+            {{- end }}
             {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}
             - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-mailing-list-service/templates/deployment.yaml
+++ b/charts/lfx-v2-mailing-list-service/templates/deployment.yaml
@@ -81,6 +81,15 @@ spec:
             - name: OTEL_TRACES_SAMPLE_RATIO
               value: {{ $otelTracesSampleRatio | quote }}
             {{- end }}
+            {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
+            {{- if ne $otelTracesSampler "" }}
+            - name: OTEL_TRACES_SAMPLER
+              value: {{ $otelTracesSampler | quote }}
+            {{- if ne $otelTracesSampleRatio "" }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ $otelTracesSampleRatio | quote }}
+            {{- end }}
+            {{- end }}
             {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}
             - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-mailing-list-service/values.yaml
+++ b/charts/lfx-v2-mailing-list-service/values.yaml
@@ -239,10 +239,6 @@ app:
     # tracesExporter specifies the traces exporter: "otlp" or "none"
     # (default: "none")
     tracesExporter: "none"
-    # tracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0)
-    # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
-    # (default: "1.0")
-    tracesSampleRatio: "1.0"
     # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
     # "always_on", "always_off", "traceidratio", "parentbased_always_on",
     # "parentbased_always_off", "parentbased_traceidratio".

--- a/charts/lfx-v2-mailing-list-service/values.yaml
+++ b/charts/lfx-v2-mailing-list-service/values.yaml
@@ -243,6 +243,11 @@ app:
     # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
     # (default: "1.0")
     tracesSampleRatio: "1.0"
+    # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
+    # "always_on", "always_off", "traceidratio", "parentbased_always_on",
+    # "parentbased_always_off", "parentbased_traceidratio".
+    # When empty, the application defaults to parentbased_traceidratio.
+    tracesSampler: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/charts/lfx-v2-mailing-list-service/values.yaml
+++ b/charts/lfx-v2-mailing-list-service/values.yaml
@@ -244,6 +244,10 @@ app:
     # "parentbased_always_off", "parentbased_traceidratio".
     # When empty, the application defaults to parentbased_traceidratio.
     tracesSampler: ""
+    # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG. For traceidratio
+    # and parentbased_traceidratio, this is a float64 between 0 and 1.
+    # When empty, the application defaults to 1.0 (always sample).
+    tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -78,6 +78,12 @@ type OTelConfig struct {
 	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
 	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
 	TracesSampleRatio float64
+	// TracesSampler specifies the sampler to use.
+	// Env: OTEL_TRACES_SAMPLER (default: "")
+	TracesSampler string
+	// TracesSamplerArg specifies the sampler argument.
+	// Env: OTEL_TRACES_SAMPLER_ARG (default: "")
+	TracesSamplerArg string
 	// MetricsExporter specifies the metrics exporter: "otlp" or "none".
 	// Env: OTEL_METRICS_EXPORTER (default: "none")
 	MetricsExporter string
@@ -144,6 +150,9 @@ func OTelConfigFromEnv() OTelConfig {
 		}
 	}
 
+	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
+	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
+
 	slog.With(
 		"service-name", serviceName,
 		"version", serviceVersion,
@@ -152,6 +161,8 @@ func OTelConfigFromEnv() OTelConfig {
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
 		"traces-sample-ratio", tracesSampleRatio,
+		"traces-sampler", tracesSampler,
+		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
 		"logs-exporter", logsExporter,
 		"propagators", propagators,
@@ -165,6 +176,8 @@ func OTelConfigFromEnv() OTelConfig {
 		Insecure:          insecure,
 		TracesExporter:    tracesExporter,
 		TracesSampleRatio: tracesSampleRatio,
+		TracesSampler:     tracesSampler,
+		TracesSamplerArg:  tracesSamplerArg,
 		MetricsExporter:   metricsExporter,
 		LogsExporter:      logsExporter,
 		Propagators:       propagators,
@@ -321,25 +334,21 @@ func endpointURL(raw string, insecure bool) string {
 }
 
 // newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
-// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
-// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
-// This ensures parent span sampling decisions are always honored.
+// OTEL_TRACES_SAMPLER_ARG, falling back to parentbased_traceidratio.
 func newSampler(cfg OTelConfig) trace.Sampler {
-	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
-	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
-
 	parseRatio := func() float64 {
-		if arg != "" {
-			r, err := strconv.ParseFloat(arg, 64)
+		if cfg.TracesSamplerArg != "" {
+			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+				"provided-value", cfg.TracesSamplerArg, "error", err)
 		}
 		return cfg.TracesSampleRatio
 	}
 
-	switch sampler {
+	switch cfg.TracesSampler {
 	case "always_on":
 		return trace.AlwaysSample()
 	case "always_off":
@@ -352,8 +361,12 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 		return trace.ParentBased(trace.NeverSample())
 	case "parentbased_traceidratio":
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
-	default: // empty/unknown → parent-based with configured ratio
-		return trace.ParentBased(trace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	default:
+		if cfg.TracesSampler != "" {
+			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
+				"provided-value", cfg.TracesSampler, "fallback-ratio", cfg.TracesSampleRatio)
+		}
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}
 }
 

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -318,11 +318,17 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 	parseRatio := func() float64 {
 		if cfg.TracesSamplerArg != "" {
 			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
-			if err == nil && r >= 0.0 && r <= 1.0 {
-				return r
+			if err != nil {
+				slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG (parse error), defaulting to 1.0",
+					"provided-value", cfg.TracesSamplerArg, "error", err)
+				return 1.0
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
-				"provided-value", cfg.TracesSamplerArg, "error", err)
+			if r < 0.0 || r > 1.0 {
+				slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG (out of range [0,1]), defaulting to 1.0",
+					"provided-value", cfg.TracesSamplerArg)
+				return 1.0
+			}
+			return r
 		}
 		return 1.0
 	}

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -313,7 +313,8 @@ func endpointURL(raw string, insecure bool) string {
 }
 
 // newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
-// OTEL_TRACES_SAMPLER_ARG, falling back to parentbased_traceidratio.
+// OTEL_TRACES_SAMPLER_ARG, defaulting to parentbased_traceidratio.
+// When TracesSamplerArg is unset or invalid, parseRatio defaults to 1.0 (100% sample rate).
 func newSampler(cfg OTelConfig) trace.Sampler {
 	parseRatio := func() float64 {
 		if cfg.TracesSamplerArg != "" {
@@ -330,6 +331,7 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 			}
 			return r
 		}
+		// No sampler arg provided: default to 1.0 (100% sample rate)
 		return 1.0
 	}
 

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -75,6 +75,7 @@ type OTelConfig struct {
 	// Env: OTEL_TRACES_EXPORTER (default: "none")
 	TracesExporter string
 	// TracesSampler specifies the sampler to use.
+	// When empty, defaults to parentbased_traceidratio with ratio 1.0.
 	// Env: OTEL_TRACES_SAMPLER (default: "")
 	TracesSampler string
 	// TracesSamplerArg specifies the sampler argument.

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -317,22 +317,21 @@ func endpointURL(raw string, insecure bool) string {
 // When TracesSamplerArg is unset or invalid, parseRatio defaults to 1.0 (100% sample rate).
 func newSampler(cfg OTelConfig) trace.Sampler {
 	parseRatio := func() float64 {
-		if cfg.TracesSamplerArg != "" {
-			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
-			if err != nil {
-				slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG (parse error), defaulting to 1.0",
-					"provided-value", cfg.TracesSamplerArg, "error", err)
-				return 1.0
-			}
-			if r < 0.0 || r > 1.0 {
-				slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG (out of range [0,1]), defaulting to 1.0",
-					"provided-value", cfg.TracesSamplerArg)
-				return 1.0
-			}
-			return r
+		if cfg.TracesSamplerArg == "" {
+			return 1.0
 		}
-		// No sampler arg provided: default to 1.0 (100% sample rate)
-		return 1.0
+		r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
+		if err != nil {
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg, "error", err)
+			return 1.0
+		}
+		if r < 0.0 || r > 1.0 {
+			slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg)
+			return 1.0
+		}
+		return r
 	}
 
 	switch cfg.TracesSampler {

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -320,6 +320,43 @@ func endpointURL(raw string, insecure bool) string {
 	return "https://" + raw
 }
 
+// newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
+// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
+// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
+// This ensures parent span sampling decisions are always honored.
+func newSampler(cfg OTelConfig) trace.Sampler {
+	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
+	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+
+	parseRatio := func() float64 {
+		if arg != "" {
+			r, err := strconv.ParseFloat(arg, 64)
+			if err == nil && r >= 0.0 && r <= 1.0 {
+				return r
+			}
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+		}
+		return cfg.TracesSampleRatio
+	}
+
+	switch sampler {
+	case "always_on":
+		return trace.AlwaysSample()
+	case "always_off":
+		return trace.NeverSample()
+	case "traceidratio":
+		return trace.TraceIDRatioBased(parseRatio())
+	case "parentbased_always_on":
+		return trace.ParentBased(trace.AlwaysSample())
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample())
+	case "parentbased_traceidratio":
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
+	default: // empty/unknown → parent-based with configured ratio
+		return trace.ParentBased(trace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	}
+}
+
 // newTraceProvider creates a TracerProvider with an OTLP exporter configured based on the protocol setting.
 func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resource) (*trace.TracerProvider, error) {
 	var exporter trace.SpanExporter
@@ -351,7 +388,7 @@ func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resourc
 
 	traceProvider := trace.NewTracerProvider(
 		trace.WithResource(res),
-		trace.WithSampler(trace.TraceIDRatioBased(cfg.TracesSampleRatio)),
+		trace.WithSampler(newSampler(cfg)),
 		trace.WithBatcher(exporter,
 			trace.WithBatchTimeout(time.Second),
 		),

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -74,10 +74,6 @@ type OTelConfig struct {
 	// TracesExporter specifies the traces exporter: "otlp" or "none".
 	// Env: OTEL_TRACES_EXPORTER (default: "none")
 	TracesExporter string
-	// TracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0).
-	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
-	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
-	TracesSampleRatio float64
 	// TracesSampler specifies the sampler to use.
 	// Env: OTEL_TRACES_SAMPLER (default: "")
 	TracesSampler string
@@ -135,21 +131,6 @@ func OTelConfigFromEnv() OTelConfig {
 		propagators = OTelDefaultPropagators
 	}
 
-	tracesSampleRatio := 1.0
-	if ratio := os.Getenv("OTEL_TRACES_SAMPLE_RATIO"); ratio != "" {
-		if parsed, err := strconv.ParseFloat(ratio, 64); err == nil {
-			if parsed >= 0.0 && parsed <= 1.0 {
-				tracesSampleRatio = parsed
-			} else {
-				slog.Warn("OTEL_TRACES_SAMPLE_RATIO must be between 0.0 and 1.0, using default 1.0",
-					"provided-value", ratio)
-			}
-		} else {
-			slog.Warn("invalid OTEL_TRACES_SAMPLE_RATIO value, using default 1.0",
-				"provided-value", ratio, "error", err)
-		}
-	}
-
 	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
 	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 
@@ -160,7 +141,6 @@ func OTelConfigFromEnv() OTelConfig {
 		"endpoint", endpoint,
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
-		"traces-sample-ratio", tracesSampleRatio,
 		"traces-sampler", tracesSampler,
 		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
@@ -169,18 +149,17 @@ func OTelConfigFromEnv() OTelConfig {
 	).Debug("OTelConfig")
 
 	return OTelConfig{
-		ServiceName:       serviceName,
-		ServiceVersion:    serviceVersion,
-		Protocol:          protocol,
-		Endpoint:          endpoint,
-		Insecure:          insecure,
-		TracesExporter:    tracesExporter,
-		TracesSampleRatio: tracesSampleRatio,
-		TracesSampler:     tracesSampler,
-		TracesSamplerArg:  tracesSamplerArg,
-		MetricsExporter:   metricsExporter,
-		LogsExporter:      logsExporter,
-		Propagators:       propagators,
+		ServiceName:      serviceName,
+		ServiceVersion:   serviceVersion,
+		Protocol:         protocol,
+		Endpoint:         endpoint,
+		Insecure:         insecure,
+		TracesExporter:   tracesExporter,
+		TracesSampler:    tracesSampler,
+		TracesSamplerArg: tracesSamplerArg,
+		MetricsExporter:  metricsExporter,
+		LogsExporter:     logsExporter,
+		Propagators:      propagators,
 	}
 }
 
@@ -342,10 +321,10 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
 				"provided-value", cfg.TracesSamplerArg, "error", err)
 		}
-		return cfg.TracesSampleRatio
+		return 1.0
 	}
 
 	switch cfg.TracesSampler {
@@ -364,7 +343,7 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 	default:
 		if cfg.TracesSampler != "" {
 			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
-				"provided-value", cfg.TracesSampler, "fallback-ratio", cfg.TracesSampleRatio)
+				"provided-value", cfg.TracesSampler)
 		}
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -85,6 +85,8 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 	t.Setenv("OTEL_PROPAGATORS", "tracecontext,baggage")
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.5")
 
 	cfg := OTelConfigFromEnv()
 
@@ -114,6 +116,12 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	}
 	if cfg.Propagators != "tracecontext,baggage" {
 		t.Errorf("expected Propagators 'tracecontext,baggage', got %q", cfg.Propagators)
+	}
+	if cfg.TracesSampler != "parentbased_traceidratio" {
+		t.Errorf("expected TracesSampler 'parentbased_traceidratio', got %q", cfg.TracesSampler)
+	}
+	if cfg.TracesSamplerArg != "0.5" {
+		t.Errorf("expected TracesSamplerArg '0.5', got %q", cfg.TracesSamplerArg)
 	}
 }
 

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -610,3 +610,49 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 
 	_ = shutdown(ctx)
 }
+
+// TestNewSampler verifies that newSampler returns a non-nil sampler for all
+// supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
+func TestNewSampler(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+
+	tests := []struct {
+		name    string
+		sampler string
+		arg     string
+	}{
+		{"default (empty)", "", ""},
+		{"always_on", "always_on", ""},
+		{"always_off", "always_off", ""},
+		{"traceidratio", "traceidratio", "0.5"},
+		{"parentbased_always_on", "parentbased_always_on", ""},
+		{"parentbased_always_off", "parentbased_always_off", ""},
+		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
+		{"unknown", "unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
+			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
+
+			s := newSampler(cfg)
+			if s == nil {
+				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+			}
+		})
+	}
+}
+
+// TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
+// falls back to cfg.TracesSampleRatio without panicking.
+func TestNewSampler_InvalidArg(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
+
+	s := newSampler(cfg)
+	if s == nil {
+		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -607,15 +607,36 @@ func TestNewSampler(t *testing.T) {
 }
 
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
-// falls back to 1.0 without panicking.
+// falls back to 1.0 (always sample) without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
+	// Test parse error case: "invalid" cannot be parsed as float64
 	cfg := OTelConfig{
-		TracesSampler:    "parentbased_traceidratio",
+		TracesSampler:    "traceidratio",
 		TracesSamplerArg: "invalid",
 	}
 	s := newSampler(cfg)
 	if s == nil {
 		t.Fatal("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+	// Should fallback to 1.0, so a root span should always be sampled
+	result := s.ShouldSample(sdktrace.SamplingParameters{})
+	if result.Decision != sdktrace.RecordAndSample {
+		t.Errorf("expected RecordAndSample with fallback ratio 1.0, got %v", result.Decision)
+	}
+
+	// Test out-of-range case: "1.5" parses but exceeds [0,1] range
+	cfg2 := OTelConfig{
+		TracesSampler:    "traceidratio",
+		TracesSamplerArg: "1.5",
+	}
+	s2 := newSampler(cfg2)
+	if s2 == nil {
+		t.Fatal("newSampler returned nil for out-of-range OTEL_TRACES_SAMPLER_ARG")
+	}
+	// Should fallback to 1.0, so a root span should always be sampled
+	result2 := s2.ShouldSample(sdktrace.SamplingParameters{})
+	if result2.Decision != sdktrace.RecordAndSample {
+		t.Errorf("expected RecordAndSample with fallback ratio 1.0, got %v", result2.Decision)
 	}
 }
 
@@ -625,11 +646,31 @@ func TestNewSampler_ParentHonored(t *testing.T) {
 	cfg := OTelConfig{}
 	s := newSampler(cfg) // default = parentbased_traceidratio
 
-	// With a sampled parent, child should also be sampled
-	sampledParent := trace.SpanContext{}.WithTraceFlags(trace.FlagsSampled)
+	// Create a valid (non-zero) parent SpanContext that is sampled
+	traceID, _ := trace.TraceIDFromHex("12345678901234567890123456789012")
+	spanID, _ := trace.SpanIDFromHex("1234567890123456")
+	sampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
 	parentCtx := trace.ContextWithRemoteSpanContext(context.Background(), sampledParent)
 	result := s.ShouldSample(sdktrace.SamplingParameters{ParentContext: parentCtx})
 	if result.Decision != sdktrace.RecordAndSample {
 		t.Errorf("expected RecordAndSample with sampled parent, got %v", result.Decision)
+	}
+
+	// Also test with unsampled parent
+	unsampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.TraceFlags(0),
+		Remote:     true,
+	})
+	parentCtx2 := trace.ContextWithRemoteSpanContext(context.Background(), unsampledParent)
+	result2 := s.ShouldSample(sdktrace.SamplingParameters{ParentContext: parentCtx2})
+	if result2.Decision != sdktrace.Drop {
+		t.Errorf("expected Drop with unsampled parent, got %v", result2.Decision)
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -5,8 +5,10 @@ package utils
 
 import (
 	"context"
-
 	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // otelEnvVars lists all OTEL-related environment variables used in tests.
@@ -18,6 +20,8 @@ var otelEnvVars = []string{
 	"OTEL_EXPORTER_OTLP_INSECURE",
 	"OTEL_TRACES_EXPORTER",
 	"OTEL_TRACES_SAMPLE_RATIO",
+	"OTEL_TRACES_SAMPLER",
+	"OTEL_TRACES_SAMPLER_ARG",
 	"OTEL_METRICS_EXPORTER",
 	"OTEL_LOGS_EXPORTER",
 	"OTEL_PROPAGATORS",
@@ -615,7 +619,6 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
 func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{TracesSampleRatio: 0.5}
-
 	tests := []struct {
 		name    string
 		sampler string
@@ -630,15 +633,17 @@ func TestNewSampler(t *testing.T) {
 		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
 		{"unknown", "unknown", ""},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
-			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
-
-			s := newSampler(cfg)
+			c := cfg
+			c.TracesSampler = tt.sampler
+			c.TracesSamplerArg = tt.arg
+			s := newSampler(c)
 			if s == nil {
-				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+				t.Fatalf("newSampler(%q) returned nil", tt.sampler)
+			}
+			if s.Description() == "" {
+				t.Errorf("newSampler(%q).Description() is empty", tt.sampler)
 			}
 		})
 	}
@@ -647,12 +652,28 @@ func TestNewSampler(t *testing.T) {
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
 // falls back to cfg.TracesSampleRatio without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
-	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
-	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
-
+	cfg := OTelConfig{
+		TracesSampleRatio: 0.5,
+		TracesSampler:     "parentbased_traceidratio",
+		TracesSamplerArg:  "invalid",
+	}
 	s := newSampler(cfg)
 	if s == nil {
-		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+		t.Fatal("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}
+
+// TestNewSampler_ParentHonored verifies that the default sampler honors
+// parent span sampling decisions.
+func TestNewSampler_ParentHonored(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 1.0}
+	s := newSampler(cfg) // default = parentbased_traceidratio
+
+	// With a sampled parent, child should also be sampled
+	sampledParent := trace.SpanContext{}.WithTraceFlags(trace.FlagsSampled)
+	parentCtx := trace.ContextWithRemoteSpanContext(context.Background(), sampledParent)
+	result := s.ShouldSample(sdktrace.SamplingParameters{ParentContext: parentCtx})
+	if result.Decision != sdktrace.RecordAndSample {
+		t.Errorf("expected RecordAndSample with sampled parent, got %v", result.Decision)
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -273,9 +273,9 @@ func TestNewPropagator_Defaults(t *testing.T) {
 
 	fields := prop.Fields()
 	expectedFields := map[string]bool{
-		"traceparent":  false,
-		"tracestate":   false,
-		"baggage":      false,
+		"traceparent":   false,
+		"tracestate":    false,
+		"baggage":       false,
 		"uber-trace-id": false,
 	}
 

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -19,7 +19,6 @@ var otelEnvVars = []string{
 	"OTEL_EXPORTER_OTLP_ENDPOINT",
 	"OTEL_EXPORTER_OTLP_INSECURE",
 	"OTEL_TRACES_EXPORTER",
-	"OTEL_TRACES_SAMPLE_RATIO",
 	"OTEL_TRACES_SAMPLER",
 	"OTEL_TRACES_SAMPLER_ARG",
 	"OTEL_METRICS_EXPORTER",
@@ -62,9 +61,6 @@ func TestOTelConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.TracesExporter != OTelExporterNone {
 		t.Errorf("expected default TracesExporter %q, got %q", OTelExporterNone, cfg.TracesExporter)
 	}
-	if cfg.TracesSampleRatio != 1.0 {
-		t.Errorf("expected default TracesSampleRatio 1.0, got %f", cfg.TracesSampleRatio)
-	}
 	if cfg.MetricsExporter != OTelExporterNone {
 		t.Errorf("expected default MetricsExporter %q, got %q", OTelExporterNone, cfg.MetricsExporter)
 	}
@@ -86,7 +82,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4318")
 	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
-	t.Setenv("OTEL_TRACES_SAMPLE_RATIO", "0.5")
 	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 	t.Setenv("OTEL_PROPAGATORS", "tracecontext,baggage")
@@ -111,9 +106,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	if cfg.TracesExporter != OTelExporterOTLP {
 		t.Errorf("expected TracesExporter %q, got %q", OTelExporterOTLP, cfg.TracesExporter)
 	}
-	if cfg.TracesSampleRatio != 0.5 {
-		t.Errorf("expected TracesSampleRatio 0.5, got %f", cfg.TracesSampleRatio)
-	}
 	if cfg.MetricsExporter != OTelExporterOTLP {
 		t.Errorf("expected MetricsExporter %q, got %q", OTelExporterOTLP, cfg.MetricsExporter)
 	}
@@ -122,38 +114,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	}
 	if cfg.Propagators != "tracecontext,baggage" {
 		t.Errorf("expected Propagators 'tracecontext,baggage', got %q", cfg.Propagators)
-	}
-}
-
-// TestOTelConfigFromEnv_TracesSampleRatio tests the parsing and validation of
-// the OTEL_TRACES_SAMPLE_RATIO environment variable, including edge cases like
-// invalid values, out-of-range numbers, and empty strings.
-func TestOTelConfigFromEnv_TracesSampleRatio(t *testing.T) {
-	tests := []struct {
-		name          string
-		envValue      string
-		expectedRatio float64
-	}{
-		{"valid zero", "0.0", 0.0},
-		{"valid half", "0.5", 0.5},
-		{"valid one", "1.0", 1.0},
-		{"valid small", "0.01", 0.01},
-		{"invalid negative", "-0.5", 1.0},      // defaults to 1.0
-		{"invalid above one", "1.5", 1.0},      // defaults to 1.0
-		{"invalid non-number", "invalid", 1.0}, // defaults to 1.0
-		{"empty string", "", 1.0},              // defaults to 1.0
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OTEL_TRACES_SAMPLE_RATIO", tt.envValue)
-
-			cfg := OTelConfigFromEnv()
-
-			if cfg.TracesSampleRatio != tt.expectedRatio {
-				t.Errorf("expected TracesSampleRatio %f, got %f", tt.expectedRatio, cfg.TracesSampleRatio)
-			}
-		})
 	}
 }
 
@@ -192,13 +152,12 @@ func TestOTelConfigFromEnv_InsecureFlag(t *testing.T) {
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		TracesExporter:    OTelExporterNone,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		TracesExporter:  OTelExporterNone,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -224,13 +183,12 @@ func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 // graceful shutdown scenarios where shutdown may be triggered multiple times.
 func TestSetupOTelSDKWithConfig_ShutdownIdempotent(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		TracesExporter:    OTelExporterNone,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		TracesExporter:  OTelExporterNone,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -590,16 +548,15 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "127.0.0.1:4317")
 
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		Endpoint:          "127.0.0.1:4317",
-		Insecure:          true,
-		TracesExporter:    OTelExporterOTLP,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
-		Propagators:       "tracecontext,baggage",
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		Endpoint:        "127.0.0.1:4317",
+		Insecure:        true,
+		TracesExporter:  OTelExporterOTLP,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
+		Propagators:     "tracecontext,baggage",
 	}
 
 	ctx := context.Background()
@@ -618,7 +575,7 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // TestNewSampler verifies that newSampler returns a non-nil sampler for all
 // supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
 func TestNewSampler(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	cfg := OTelConfig{}
 	tests := []struct {
 		name    string
 		sampler string
@@ -650,12 +607,11 @@ func TestNewSampler(t *testing.T) {
 }
 
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
-// falls back to cfg.TracesSampleRatio without panicking.
+// falls back to 1.0 without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
 	cfg := OTelConfig{
-		TracesSampleRatio: 0.5,
-		TracesSampler:     "parentbased_traceidratio",
-		TracesSamplerArg:  "invalid",
+		TracesSampler:    "parentbased_traceidratio",
+		TracesSamplerArg: "invalid",
 	}
 	s := newSampler(cfg)
 	if s == nil {
@@ -666,7 +622,7 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 // TestNewSampler_ParentHonored verifies that the default sampler honors
 // parent span sampling decisions.
 func TestNewSampler_ParentHonored(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 1.0}
+	cfg := OTelConfig{}
 	s := newSampler(cfg) // default = parentbased_traceidratio
 
 	// With a sampled parent, child should also be sampled


### PR DESCRIPTION
## Summary

Fixes LFXV2-1734 — all Go service spans have \`parentid: 0\` in Datadog because \`TraceIDRatioBased\` makes independent sampling decisions, ignoring incoming \`traceparent\` headers.

## Changes

**\`pkg/utils/otel.go\`** — Replace bare \`trace.TraceIDRatioBased(ratio)\` with a new \`newSampler(cfg)\` function that:
- Reads \`OTEL_TRACES_SAMPLER\` / \`OTEL_TRACES_SAMPLER_ARG\` (standard OTel env vars)
- Defaults to \`parentbased_traceidratio\` with ratio \`1.0\` when unset
- Supports all 6 OTel sampler types: \`always_on\`, \`always_off\`, \`traceidratio\`, \`parentbased_always_on\`, \`parentbased_always_off\`, \`parentbased_traceidratio\`
- Removes \`TracesSampleRatio\` / \`OTEL_TRACES_SAMPLE_RATIO\` entirely — no backward compatibility fallback; configure sampling via \`OTEL_TRACES_SAMPLER_ARG\`

**\`pkg/utils/otel_test.go\`** — Added \`TestNewSampler\`, \`TestNewSampler_InvalidArg\`, and \`TestNewSampler_ParentHonored\`; updated \`TestOTelConfigFromEnv_CustomValues\` to cover \`OTEL_TRACES_SAMPLER\` and \`OTEL_TRACES_SAMPLER_ARG\`

**\`charts/lfx-v2-mailing-list-service/templates/deployment.yaml\`** — Renders \`OTEL_TRACES_SAMPLER\` when \`app.otel.tracesSampler\` is non-empty; renders \`OTEL_TRACES_SAMPLER_ARG\` when \`app.otel.tracesSamplerArg\` is non-empty (independent conditions)

**\`charts/lfx-v2-mailing-list-service/values.yaml\`** — Added \`tracesSampler: ""\` and \`tracesSamplerArg: ""\` to \`app.otel\`

## Why

\`TraceIDRatioBased\` re-decides sampling per span regardless of the parent's sampling flag. Wrapping with \`parentbased_traceidratio\` ensures child spans always follow the parent's decision, restoring end-to-end trace continuity.

\`OTEL_TRACES_SAMPLER_ARG\` replaces the old \`OTEL_TRACES_SAMPLE_RATIO\` / \`TracesSampleRatio\` mechanism. All deployments have been updated in ArgoCD values to use \`tracesSamplerArg\` directly. No backward compatibility fallback is provided.

Issue: LFXV2-1734