### PR TITLE
[LFXV2-1737] feat(otel): instrument outbound HTTP clients

### DIFF
--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -12,8 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"net/http"
+
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -141,7 +144,8 @@ func NewJWTAuth(config JWTAuthConfig) (*JWTAuth, error) {
 		slog.Error("unexpected URL parsing of default issuer")
 		return nil, err
 	}
-	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL))
+	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL), jwks.WithCustomClient(otelClient))
 
 	// Set up the JWT validator.
 	jwtValidator, err := validator.New(

--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -8,11 +8,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
-
-	"net/http"
 
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
@@ -25,6 +24,7 @@ const (
 	defaultIssuer      = "heimdall"
 	defaultAudience    = "lfx-v2-mailing-list-service"
 	defaultJWKSURL     = "http://heimdall:4457/.well-known/jwks"
+	jwksClientTimeout  = 10 * time.Second
 )
 
 // JWTAuthConfig holds the configuration parameters for JWT authentication.
@@ -68,7 +68,7 @@ type JWTAuth struct {
 
 // ParsePrincipal extracts the principal from the JWT claims.
 func (j *JWTAuth) ParsePrincipal(ctx context.Context, token string, logger *slog.Logger) (string, error) {
-  	// To avoid having to use a valid JWT token for local development, we can use the
+	// To avoid having to use a valid JWT token for local development, we can use the
 	// MockLocalPrincipal configuration parameter.
 	if j.config.MockLocalPrincipal != "" {
 		logger.InfoContext(ctx, "JWT authentication is disabled, returning mock principal",
@@ -144,7 +144,10 @@ func NewJWTAuth(config JWTAuthConfig) (*JWTAuth, error) {
 		slog.Error("unexpected URL parsing of default issuer")
 		return nil, err
 	}
-	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	otelClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   jwksClientTimeout,
+	}
 	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL), jwks.WithCustomClient(otelClient))
 
 	// Set up the JWT validator.

--- a/internal/infrastructure/proxy/itx.go
+++ b/internal/infrastructure/proxy/itx.go
@@ -597,8 +597,8 @@ func NewProxy(ctx context.Context, config Config) (port.GroupsIOReaderWriter, er
 		return nil, fmt.Errorf("ITX client private key is required")
 	}
 
-	// Create otel-instrumented HTTP client to use for both Auth0 token
-	// requests and ITX API calls, so both appear as child spans in traces.
+	// Create an otel-instrumented HTTP client for Auth0 token requests;
+	// ITX API calls are instrumented separately via oauthHTTPClient below.
 	otelClient := &http.Client{
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 		Timeout:   config.Timeout,

--- a/internal/infrastructure/proxy/itx.go
+++ b/internal/infrastructure/proxy/itx.go
@@ -599,7 +599,10 @@ func NewProxy(ctx context.Context, config Config) (port.GroupsIOReaderWriter, er
 
 	// Create otel-instrumented HTTP client to use for both Auth0 token
 	// requests and ITX API calls, so both appear as child spans in traces.
-	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	otelClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   config.Timeout,
+	}
 
 	authConfig, err := authentication.New(
 		ctx,

--- a/internal/infrastructure/proxy/itx.go
+++ b/internal/infrastructure/proxy/itx.go
@@ -21,6 +21,7 @@ import (
 	pkgauth "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/auth"
 	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/httpclient"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
 )
 
@@ -596,11 +597,16 @@ func NewProxy(ctx context.Context, config Config) (port.GroupsIOReaderWriter, er
 		return nil, fmt.Errorf("ITX client private key is required")
 	}
 
+	// Create otel-instrumented HTTP client to use for both Auth0 token
+	// requests and ITX API calls, so both appear as child spans in traces.
+	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+
 	authConfig, err := authentication.New(
 		ctx,
 		config.Auth0Domain,
 		authentication.WithClientID(config.ClientID),
 		authentication.WithClientAssertion(config.PrivateKey, "RS256"),
+		authentication.WithClient(otelClient),
 	)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to create Auth0 authentication client", "error", err)
@@ -608,7 +614,9 @@ func NewProxy(ctx context.Context, config Config) (port.GroupsIOReaderWriter, er
 	}
 
 	tokenSource := pkgauth.NewAuth0TokenSource(ctx, authConfig, config.Audience, itxScope)
+	// Wrap the oauth2 transport with otelhttp so ITX API calls appear in traces.
 	oauthHTTPClient := oauth2.NewClient(ctx, oauth2.ReuseTokenSource(nil, tokenSource))
+	oauthHTTPClient.Transport = otelhttp.NewTransport(oauthHTTPClient.Transport)
 	oauthHTTPClient.Timeout = config.Timeout
 
 	return &itx{


### PR DESCRIPTION
## Summary

Part of [LFXV2-1737](https://linuxfoundation.atlassian.net/browse/LFXV2-1737).

- Wraps the JWKS HTTP client with `otelhttp.NewTransport` so Heimdall key-fetch requests appear as child spans in distributed traces
- Wraps the Auth0 HTTP client with `otelhttp.NewTransport` so token acquisition appears in traces; Auth0 spans are **independent** (not child spans of inbound requests) because the token source uses `context.Background()` — it is shared and cached across requests
- Wraps the ITX API HTTP client with `otelhttp.NewTransport` so ITX calls appear as **child spans** of inbound request spans
- Adds `jwksClientTimeout` (10s) to bound JWKS fetch time; uses `config.Timeout` for the Auth0 client
- Fixes stdlib import grouping (`net/http` moved into stdlib group per `goimports`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1737]: https://linuxfoundation.atlassian.net/browse/LFXV2-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ