### PR TITLE
feat(auth): allow committee writers to create mailing lists for their committee

### DIFF
--- a/charts/lfx-v2-mailing-list-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-mailing-list-service/templates/ruleset.yaml
@@ -179,11 +179,13 @@ spec:
         {{- if .Values.openfga.enabled }}
         - authorizer: json_content_type
 
-        - authorizer: openfga_check
+        - authorizer: openfga_or_check
           config:
             values:
               relation: writer
               object: "groupsio_service:{{ "{{- .Request.Body.service_id -}}" }}"
+              or_relation: "{{ "{{- if .Request.Body.committee_uid -}}writer{{- end -}}" }}"
+              or_object: "{{ "{{- if .Request.Body.committee_uid -}}committee:{{- .Request.Body.committee_uid -}}{{- end -}}" }}"
         {{- else }}
         - authorizer: allow_all
         {{- end }}

--- a/cmd/mailing-list-api/main.go
+++ b/cmd/mailing-list-api/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/cmd/mailing-list-api/service"
 	mailinglistservice "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/mailing_list"
+	infraNATS "github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/infrastructure/nats"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/infrastructure/proxy"
 	orchestrator "github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/service"
 	logging "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/log"
@@ -116,11 +117,15 @@ func main() {
 
 	mailingListEventPublisher := service.MessagePublisher(ctx)
 
+	committeeProjectLookup := infraNATS.NewNATSCommitteeProjectLookup(service.GetNATSClient(ctx))
+
 	mailingListOrchestrator := orchestrator.NewGroupsIOMailingListOrchestrator(
 		orchestrator.WithMailingListWriter(proxyClient),
 		orchestrator.WithMailingListTranslator(translator),
 		orchestrator.WithMailingListEventReader(mailingListReaderOrchestrator),
 		orchestrator.WithMailingListPublisher(mailingListEventPublisher),
+		orchestrator.WithMailingListServiceReader(serviceReaderOrchestrator),
+		orchestrator.WithMailingListCommitteeProjectLookup(committeeProjectLookup),
 	)
 
 	memberReaderOrchestrator := orchestrator.NewGroupsIOMailingListMemberReaderOrchestrator(

--- a/cmd/mailing-list-api/main.go
+++ b/cmd/mailing-list-api/main.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/cmd/mailing-list-api/service"
 	mailinglistservice "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/mailing_list"
-	infraNATS "github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/infrastructure/nats"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/infrastructure/proxy"
 	orchestrator "github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/service"
 	logging "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/log"
@@ -117,7 +116,7 @@ func main() {
 
 	mailingListEventPublisher := service.MessagePublisher(ctx)
 
-	committeeProjectLookup := infraNATS.NewNATSCommitteeProjectLookup(service.GetNATSClient(ctx))
+	committeeProjectLookup := service.CommitteeProjectLookup(ctx)
 
 	mailingListOrchestrator := orchestrator.NewGroupsIOMailingListOrchestrator(
 		orchestrator.WithMailingListWriter(proxyClient),

--- a/cmd/mailing-list-api/service/providers.go
+++ b/cmd/mailing-list-api/service/providers.go
@@ -219,3 +219,27 @@ func MessagePublisher(ctx context.Context) port.MessagePublisher {
 
 	return publisher
 }
+
+// CommitteeProjectLookup initializes the committee project lookup implementation.
+// REPOSITORY_SOURCE controls which backend is used (default: "nats").
+func CommitteeProjectLookup(ctx context.Context) port.CommitteeProjectLookup {
+	repoSource := os.Getenv("REPOSITORY_SOURCE")
+	if repoSource == "" {
+		repoSource = "nats"
+	}
+
+	switch repoSource {
+	case "mock":
+		slog.InfoContext(ctx, "initializing mock committee project lookup")
+		return infrastructure.NewFakeCommitteeProjectLookup()
+
+	case "nats":
+		slog.InfoContext(ctx, "initializing NATS committee project lookup")
+		return nats.NewNATSCommitteeProjectLookup(GetNATSClient(ctx))
+
+	default:
+		log.Fatalf("unsupported committee project lookup implementation: %s", repoSource)
+	}
+
+	return nil
+}

--- a/internal/domain/port/committee_project_lookup.go
+++ b/internal/domain/port/committee_project_lookup.go
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package port
+
+import "context"
+
+// CommitteeProjectLookup resolves a v2 committee UID to its owning v2 project UID.
+// Implementations query lfx-v2-committee-service via NATS request-reply on
+// constants.CommitteeGetProjectSubject.
+type CommitteeProjectLookup interface {
+	// GetCommitteeProject returns the v2 project UID that owns the given v2 committee UID.
+	// Returns NotFound when no committee exists for the supplied UID.
+	GetCommitteeProject(ctx context.Context, committeeUID string) (string, error)
+}

--- a/internal/infrastructure/mock/committee_project_lookup.go
+++ b/internal/infrastructure/mock/committee_project_lookup.go
@@ -26,8 +26,11 @@ func NewFakeCommitteeProjectLookup() *FakeCommitteeProjectLookup {
 }
 
 // GetCommitteeProject returns the pre-configured project UID for committeeUID.
-// Returns NotFound when no entry is set (matching the real implementation).
+// Returns Validation for empty UID and NotFound when no entry is set (matching the real implementation).
 func (f *FakeCommitteeProjectLookup) GetCommitteeProject(_ context.Context, committeeUID string) (string, error) {
+	if committeeUID == "" {
+		return "", errs.NewValidation("committee UID is required")
+	}
 	if f.Err != nil {
 		return "", f.Err
 	}

--- a/internal/infrastructure/mock/committee_project_lookup.go
+++ b/internal/infrastructure/mock/committee_project_lookup.go
@@ -1,0 +1,39 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package mock
+
+import (
+	"context"
+
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
+	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
+)
+
+// FakeCommitteeProjectLookup is a test double for port.CommitteeProjectLookup.
+// Pre-populate Projects with committeeUID → projectUID entries as needed.
+// Set Err to simulate a transient failure.
+type FakeCommitteeProjectLookup struct {
+	Projects map[string]string
+	Err      error
+}
+
+var _ port.CommitteeProjectLookup = (*FakeCommitteeProjectLookup)(nil)
+
+// NewFakeCommitteeProjectLookup returns a FakeCommitteeProjectLookup with an empty map.
+func NewFakeCommitteeProjectLookup() *FakeCommitteeProjectLookup {
+	return &FakeCommitteeProjectLookup{Projects: make(map[string]string)}
+}
+
+// GetCommitteeProject returns the pre-configured project UID for committeeUID.
+// Returns NotFound when no entry is set (matching the real implementation).
+func (f *FakeCommitteeProjectLookup) GetCommitteeProject(_ context.Context, committeeUID string) (string, error) {
+	if f.Err != nil {
+		return "", f.Err
+	}
+	projectUID, ok := f.Projects[committeeUID]
+	if !ok {
+		return "", errs.NewNotFound("committee not found")
+	}
+	return projectUID, nil
+}

--- a/internal/infrastructure/nats/committee_project_lookup.go
+++ b/internal/infrastructure/nats/committee_project_lookup.go
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
+	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
+	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	committeeProjectLookupTimeout = 5 * time.Second
+)
+
+type committeeProjectLookupRequest struct {
+	CommitteeUID string `json:"committee_uid"`
+}
+
+type committeeProjectLookupResponse struct {
+	ProjectUID string `json:"project_uid,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// natsCommitteeProjectLookup implements port.CommitteeProjectLookup using NATS
+// request/reply against lfx-v2-committee-service on CommitteeGetProjectSubject.
+type natsCommitteeProjectLookup struct {
+	conn    *nats.Conn
+	timeout time.Duration
+}
+
+// GetCommitteeProject resolves committeeUID to its owning v2 project UID.
+func (c *natsCommitteeProjectLookup) GetCommitteeProject(ctx context.Context, committeeUID string) (string, error) {
+	if committeeUID == "" {
+		return "", errs.NewValidation("committee UID is required")
+	}
+
+	reqBytes, err := json.Marshal(committeeProjectLookupRequest{CommitteeUID: committeeUID})
+	if err != nil {
+		return "", errs.NewUnexpected("failed to marshal committee project lookup request", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	msg, err := requestWithSpan(reqCtx, c.conn, constants.CommitteeGetProjectSubject, reqBytes)
+	if err != nil {
+		if err == context.DeadlineExceeded || err == nats.ErrTimeout {
+			return "", errs.NewServiceUnavailable("committee project lookup timed out", err)
+		}
+		return "", errs.NewServiceUnavailable("committee project lookup failed", err)
+	}
+
+	var resp committeeProjectLookupResponse
+	if err := json.Unmarshal(msg.Data, &resp); err != nil {
+		return "", errs.NewServiceUnavailable("failed to parse committee project lookup response", err)
+	}
+
+	if resp.Error != "" {
+		if resp.Error == "not found" {
+			return "", errs.NewNotFound(resp.Error)
+		}
+		return "", errs.NewValidation(resp.Error)
+	}
+
+	return resp.ProjectUID, nil
+}
+
+// NewNATSCommitteeProjectLookup creates a CommitteeProjectLookup backed by the given NATSClient.
+func NewNATSCommitteeProjectLookup(client *NATSClient) port.CommitteeProjectLookup {
+	return &natsCommitteeProjectLookup{
+		conn:    client.conn,
+		timeout: committeeProjectLookupTimeout,
+	}
+}

--- a/internal/infrastructure/nats/committee_project_lookup.go
+++ b/internal/infrastructure/nats/committee_project_lookup.go
@@ -6,6 +6,7 @@ package nats
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
@@ -62,10 +63,14 @@ func (c *natsCommitteeProjectLookup) GetCommitteeProject(ctx context.Context, co
 	}
 
 	if resp.Error != "" {
-		if resp.Error == "not found" {
+		if strings.Contains(strings.ToLower(resp.Error), "not found") {
 			return "", errs.NewNotFound(resp.Error)
 		}
 		return "", errs.NewValidation(resp.Error)
+	}
+
+	if resp.ProjectUID == "" {
+		return "", errs.NewServiceUnavailable("committee project lookup returned empty project UID")
 	}
 
 	return resp.ProjectUID, nil

--- a/internal/service/grpsio_mailing_list_writer.go
+++ b/internal/service/grpsio_mailing_list_writer.go
@@ -11,16 +11,19 @@ import (
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
+	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
 )
 
 // GroupsIOMailingListOrchestrator implements port.GroupsIOMailingListWriter by wrapping an inner
 // GroupsIOMailingListWriter and translating v2 UUIDs to v1 SFIDs before forwarding requests.
 // It also publishes committee mailing list status events after each mutation.
 type GroupsIOMailingListOrchestrator struct {
-	writer     port.GroupsIOMailingListWriter
-	reader     port.GroupsIOMailingListReader
-	translator port.Translator
-	publisher  port.MessagePublisher
+	writer                 port.GroupsIOMailingListWriter
+	reader                 port.GroupsIOMailingListReader
+	translator             port.Translator
+	publisher              port.MessagePublisher
+	serviceReader          port.GroupsIOServiceReader
+	committeeProjectLookup port.CommitteeProjectLookup
 }
 
 // MailingListOrchestratorOption configures a GroupsIOMailingListOrchestrator.
@@ -55,10 +58,57 @@ func WithMailingListPublisher(p port.MessagePublisher) MailingListOrchestratorOp
 	}
 }
 
+// WithMailingListServiceReader sets the service reader used to resolve a service's project.
+func WithMailingListServiceReader(r port.GroupsIOServiceReader) MailingListOrchestratorOption {
+	return func(o *GroupsIOMailingListOrchestrator) {
+		o.serviceReader = r
+	}
+}
+
+// WithMailingListCommitteeProjectLookup sets the lookup used to resolve a committee's project.
+func WithMailingListCommitteeProjectLookup(l port.CommitteeProjectLookup) MailingListOrchestratorOption {
+	return func(o *GroupsIOMailingListOrchestrator) {
+		o.committeeProjectLookup = l
+	}
+}
+
+// validateCommitteeProject checks that the supplied committee belongs to the same project as
+// the parent service. No-op when no committee is present or either dependency is unset.
+// On success it sets ml.ProjectUID from the authoritative service record.
+func (o *GroupsIOMailingListOrchestrator) validateCommitteeProject(ctx context.Context, ml *model.GroupsIOMailingList) error {
+	if len(ml.Committees) == 0 || ml.Committees[0].UID == "" {
+		return nil
+	}
+	if o.serviceReader == nil || o.committeeProjectLookup == nil {
+		return nil
+	}
+
+	svc, err := o.serviceReader.GetService(ctx, ml.ServiceUID)
+	if err != nil {
+		return err
+	}
+
+	committeeProject, err := o.committeeProjectLookup.GetCommitteeProject(ctx, ml.Committees[0].UID)
+	if err != nil {
+		return err
+	}
+
+	if committeeProject != svc.ProjectUID {
+		return errs.NewValidation("committee does not belong to the service's project")
+	}
+
+	ml.ProjectUID = svc.ProjectUID
+	return nil
+}
+
 // CreateMailingList creates a new mailing list, mapping project_uid (v2) -> project_id (v1)
 // and committee_uid (v2) -> committee_id (v1) before forwarding.
 // After a successful create it publishes a committee mailing list status event.
 func (o *GroupsIOMailingListOrchestrator) CreateMailingList(ctx context.Context, ml *model.GroupsIOMailingList) (*model.GroupsIOMailingList, error) {
+	if err := o.validateCommitteeProject(ctx, ml); err != nil {
+		return nil, err
+	}
+
 	toSend, err := o.mapMailingListRequest(ctx, ml)
 	if err != nil {
 		return nil, err
@@ -94,6 +144,10 @@ func (o *GroupsIOMailingListOrchestrator) CreateMailingList(ctx context.Context,
 //     committee is shared across multiple mailing lists.
 //   - notifyCommitteeAdded always publishes has_mailing_list=true unconditionally.
 func (o *GroupsIOMailingListOrchestrator) UpdateMailingList(ctx context.Context, mailingListID string, ml *model.GroupsIOMailingList) (*model.GroupsIOMailingList, error) {
+	if err := o.validateCommitteeProject(ctx, ml); err != nil {
+		return nil, err
+	}
+
 	// Snapshot the current committee association before the update so we can detect changes.
 	oldCUID := o.fetchCommitteeUID(ctx, mailingListID)
 

--- a/internal/service/grpsio_mailing_list_writer.go
+++ b/internal/service/grpsio_mailing_list_writer.go
@@ -73,19 +73,27 @@ func WithMailingListCommitteeProjectLookup(l port.CommitteeProjectLookup) Mailin
 }
 
 // validateCommitteeProject checks that the supplied committee belongs to the same project as
-// the parent service. No-op when no committee is present or either dependency is unset.
-// On success it sets ml.ProjectUID from the authoritative service record.
+// the parent service. No-op when no committee is present. Returns ServiceUnavailable when
+// required dependencies are not configured. On success it sets ml.ProjectUID from the
+// authoritative service record.
 func (o *GroupsIOMailingListOrchestrator) validateCommitteeProject(ctx context.Context, ml *model.GroupsIOMailingList) error {
 	if len(ml.Committees) == 0 || ml.Committees[0].UID == "" {
 		return nil
 	}
 	if o.serviceReader == nil || o.committeeProjectLookup == nil {
-		return nil
+		return errs.NewServiceUnavailable("committee project validation is not configured")
+	}
+
+	if ml.ServiceUID == "" {
+		return errs.NewValidation("service_id is required when committee_uid is provided")
 	}
 
 	svc, err := o.serviceReader.GetService(ctx, ml.ServiceUID)
 	if err != nil {
 		return err
+	}
+	if svc == nil {
+		return errs.NewServiceUnavailable("service reader returned nil service")
 	}
 
 	committeeProject, err := o.committeeProjectLookup.GetCommitteeProject(ctx, ml.Committees[0].UID)

--- a/internal/service/grpsio_mailing_list_writer_test.go
+++ b/internal/service/grpsio_mailing_list_writer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/constants"
+	errs "github.com/linuxfoundation/lfx-v2-mailing-list-service/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,6 +96,37 @@ func (p *passthroughTranslator) MapID(_ context.Context, _, _, fromID string) (s
 
 var _ port.Translator = (*passthroughTranslator)(nil)
 
+// stubServiceReader returns the configured service/err from GetService.
+type stubServiceReader struct {
+	svc *model.GroupsIOService
+	err error
+}
+
+func (r *stubServiceReader) GetService(_ context.Context, _ string) (*model.GroupsIOService, error) {
+	return r.svc, r.err
+}
+func (r *stubServiceReader) ListServices(_ context.Context, _ string) ([]*model.GroupsIOService, int, error) {
+	return nil, 0, nil
+}
+func (r *stubServiceReader) GetProjects(_ context.Context) ([]string, error) { return nil, nil }
+func (r *stubServiceReader) FindParentService(_ context.Context, _ string) (*model.GroupsIOService, error) {
+	return nil, nil
+}
+
+var _ port.GroupsIOServiceReader = (*stubServiceReader)(nil)
+
+// stubCommitteeProjectLookup returns the configured projectUID/err from GetCommitteeProject.
+type stubCommitteeProjectLookup struct {
+	projectUID string
+	err        error
+}
+
+func (s *stubCommitteeProjectLookup) GetCommitteeProject(_ context.Context, _ string) (string, error) {
+	return s.projectUID, s.err
+}
+
+var _ port.CommitteeProjectLookup = (*stubCommitteeProjectLookup)(nil)
+
 // ---- helpers ----
 
 func mlWith(committeeUID string) *model.GroupsIOMailingList {
@@ -113,6 +145,30 @@ func newTestOrchestrator(
 		reader:     reader,
 		translator: &passthroughTranslator{},
 		publisher:  pub,
+	}
+}
+
+func newTestOrchestratorWithValidation(
+	writer port.GroupsIOMailingListWriter,
+	reader port.GroupsIOMailingListReader,
+	pub port.MessagePublisher,
+	svcReader port.GroupsIOServiceReader,
+	committeeProjectLookup port.CommitteeProjectLookup,
+) *GroupsIOMailingListOrchestrator {
+	return &GroupsIOMailingListOrchestrator{
+		writer:                 writer,
+		reader:                 reader,
+		translator:             &passthroughTranslator{},
+		publisher:              pub,
+		serviceReader:          svcReader,
+		committeeProjectLookup: committeeProjectLookup,
+	}
+}
+
+func mlWithService(committeeUID, serviceUID string) *model.GroupsIOMailingList {
+	return &model.GroupsIOMailingList{
+		ServiceUID: serviceUID,
+		Committees: []model.Committee{{UID: committeeUID}},
 	}
 }
 
@@ -473,4 +529,117 @@ func TestCommitteeHasRemainingMailingLists_Empty_ReturnsFalse(t *testing.T) {
 	reader := &stubMLReader{listMLs: []*model.GroupsIOMailingList{}}
 	o := newTestOrchestrator(&stubMLWriter{}, reader, nil)
 	assert.False(t, o.committeeHasRemainingMailingLists(context.Background(), "c-1", "ml-1"))
+}
+
+// ---- validateCommitteeProject ----
+
+func TestValidateCommitteeProject_NoCommittee_Skips(t *testing.T) {
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := &model.GroupsIOMailingList{ServiceUID: "svc-1"}
+	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
+}
+
+func TestValidateCommitteeProject_NilServiceReader_Skips(t *testing.T) {
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, nil, lookup)
+
+	ml := mlWithService("committee-1", "svc-1")
+	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
+}
+
+func TestValidateCommitteeProject_NilLookup_Skips(t *testing.T) {
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, nil)
+
+	ml := mlWithService("committee-1", "svc-1")
+	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
+}
+
+func TestValidateCommitteeProject_SameProject_Passes(t *testing.T) {
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := mlWithService("committee-1", "svc-1")
+	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
+	assert.Equal(t, "proj-A", ml.ProjectUID, "ProjectUID should be set from the service")
+}
+
+func TestValidateCommitteeProject_DifferentProject_ReturnsValidationError(t *testing.T) {
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-B"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := mlWithService("committee-1", "svc-1")
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.IsType(t, errs.Validation{}, err)
+}
+
+func TestValidateCommitteeProject_ServiceReaderError_Propagates(t *testing.T) {
+	svcErr := errors.New("service not found")
+	svcReader := &stubServiceReader{err: svcErr}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := mlWithService("committee-1", "svc-1")
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.Equal(t, svcErr, err)
+}
+
+func TestValidateCommitteeProject_LookupError_Propagates(t *testing.T) {
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookupErr := errors.New("committee not found")
+	lookup := &stubCommitteeProjectLookup{err: lookupErr}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := mlWithService("committee-1", "svc-1")
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.Equal(t, lookupErr, err)
+}
+
+// ---- CreateMailingList + UpdateMailingList validation integration ----
+
+func TestCreateMailingList_CrossProjectCommittee_ReturnsError(t *testing.T) {
+	spy := &spyInternalPublisher{}
+	writer := &stubMLWriter{createResp: mlWith("committee-1")}
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-B"}
+	o := newTestOrchestratorWithValidation(writer, nil, spy, svcReader, lookup)
+
+	_, err := o.CreateMailingList(context.Background(), mlWithService("committee-1", "svc-1"))
+	require.Error(t, err)
+	assert.IsType(t, errs.Validation{}, err)
+	assert.Empty(t, spy.calls, "no event published on validation failure")
+}
+
+func TestCreateMailingList_SameProjectCommittee_Succeeds(t *testing.T) {
+	spy := &spyInternalPublisher{}
+	writer := &stubMLWriter{createResp: mlWith("committee-1")}
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(writer, nil, spy, svcReader, lookup)
+
+	resp, err := o.CreateMailingList(context.Background(), mlWithService("committee-1", "svc-1"))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestUpdateMailingList_CrossProjectCommittee_ReturnsError(t *testing.T) {
+	spy := &spyInternalPublisher{}
+	writer := &stubMLWriter{updateResp: mlWith("committee-1")}
+	reader := &stubMLReader{ml: mlWith("committee-old")}
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-B"}
+	o := newTestOrchestratorWithValidation(writer, reader, spy, svcReader, lookup)
+
+	_, err := o.UpdateMailingList(context.Background(), "ml-1", mlWithService("committee-1", "svc-1"))
+	require.Error(t, err)
+	assert.IsType(t, errs.Validation{}, err)
+	assert.Empty(t, spy.calls, "no event published on validation failure")
 }

--- a/internal/service/grpsio_mailing_list_writer_test.go
+++ b/internal/service/grpsio_mailing_list_writer_test.go
@@ -131,6 +131,7 @@ var _ port.CommitteeProjectLookup = (*stubCommitteeProjectLookup)(nil)
 
 func mlWith(committeeUID string) *model.GroupsIOMailingList {
 	return &model.GroupsIOMailingList{
+		ServiceUID: "test-service",
 		Committees: []model.Committee{{UID: committeeUID}},
 	}
 }
@@ -141,10 +142,12 @@ func newTestOrchestrator(
 	pub port.MessagePublisher,
 ) *GroupsIOMailingListOrchestrator {
 	return &GroupsIOMailingListOrchestrator{
-		writer:     writer,
-		reader:     reader,
-		translator: &passthroughTranslator{},
-		publisher:  pub,
+		writer:                 writer,
+		reader:                 reader,
+		translator:             &passthroughTranslator{},
+		publisher:              pub,
+		serviceReader:          &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "test-project"}},
+		committeeProjectLookup: &stubCommitteeProjectLookup{projectUID: "test-project"},
 	}
 }
 
@@ -542,20 +545,48 @@ func TestValidateCommitteeProject_NoCommittee_Skips(t *testing.T) {
 	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
 }
 
-func TestValidateCommitteeProject_NilServiceReader_Skips(t *testing.T) {
+func TestValidateCommitteeProject_NilServiceReader_ReturnsServiceUnavailable(t *testing.T) {
 	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
 	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, nil, lookup)
 
 	ml := mlWithService("committee-1", "svc-1")
-	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.IsType(t, errs.ServiceUnavailable{}, err)
 }
 
-func TestValidateCommitteeProject_NilLookup_Skips(t *testing.T) {
+func TestValidateCommitteeProject_NilLookup_ReturnsServiceUnavailable(t *testing.T) {
 	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
 	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, nil)
 
 	ml := mlWithService("committee-1", "svc-1")
-	require.NoError(t, o.validateCommitteeProject(context.Background(), ml))
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.IsType(t, errs.ServiceUnavailable{}, err)
+}
+
+func TestValidateCommitteeProject_NilService_ReturnsServiceUnavailable(t *testing.T) {
+	svcReader := &stubServiceReader{svc: nil} // returns nil, nil
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := mlWithService("committee-1", "svc-1")
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.IsType(t, errs.ServiceUnavailable{}, err)
+}
+
+func TestValidateCommitteeProject_MissingServiceUID_ReturnsValidationError(t *testing.T) {
+	svcReader := &stubServiceReader{svc: &model.GroupsIOService{ProjectUID: "proj-A"}}
+	lookup := &stubCommitteeProjectLookup{projectUID: "proj-A"}
+	o := newTestOrchestratorWithValidation(&stubMLWriter{}, nil, nil, svcReader, lookup)
+
+	ml := &model.GroupsIOMailingList{
+		Committees: []model.Committee{{UID: "committee-1"}},
+	}
+	err := o.validateCommitteeProject(context.Background(), ml)
+	require.Error(t, err)
+	assert.IsType(t, errs.Validation{}, err)
 }
 
 func TestValidateCommitteeProject_SameProject_Passes(t *testing.T) {

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -19,6 +19,11 @@ const (
 	CommitteeMemberUpdatedSubject = "lfx.committee-api.committee_member.updated"
 	CommitteeListMembersSubject   = "lfx.committee-api.list_members"
 
+	// CommitteeGetProjectSubject is the request-reply subject for resolving a v2 committee UID
+	// to its owning v2 project UID. Served by lfx-v2-committee-service (LFXV2-2472).
+	// Request: JSON {"committee_uid":"<uuid>"}  Response: JSON {"project_uid":"<uuid>"} or {"error":"<msg>"}
+	CommitteeGetProjectSubject = "lfx.committee-api.get_project"
+
 	// Mailing list events from mailing-list-api
 	MailingListCreatedSubject = "lfx.mailing-list-api.mailing_list_created"
 	MailingListUpdatedSubject = "lfx.mailing-list-api.mailing_list_updated"


### PR DESCRIPTION
## Summary

- Switches the mailing list create rule (`POST /groupsio/mailing-lists`) in `ruleset.yaml` from `openfga_check` to `openfga_or_check`
- Adds a conditional secondary check: when `committee_uid` is present in the request body, users who are `writer` on that committee are also permitted to create the mailing list
- Primary service-writer path and the local-dev `allow_all` path are unchanged

Closes LFXV2-2469. Follows the same pattern as LFXV2-2395 / lfx-v2-meeting-service PR #202.

**Prerequisite:** The `openfga_or_check` authorizer definition must be deployed in `lfx-v2-helm`/`lfx-v2-argocd` (expected to already be present from LFXV2-2395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)