### PR TITLE
feat(nats): add NATS span instrumentation to mailing-list-service

### DIFF
--- a/internal/infrastructure/nats/tracing.go
+++ b/internal/infrastructure/nats/tracing.go
@@ -14,9 +14,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// tracer is safe to initialize at package level — otel.Tracer() returns a
+// delegating tracer that forwards to whatever TracerProvider is registered at
+// call time, so otel.SetTracerProvider() updates it regardless of init order.
 var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-mailing-list-service/internal/infrastructure/nats")
 
-// natsHeaderCarrier adapts nats.Header to propagation.TextMapCarrier.
+// natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
+// so trace context can be injected/extracted from NATS message headers.
 type natsHeaderCarrier natsgo.Header
 
 func (c natsHeaderCarrier) Get(key string) string {
@@ -44,53 +48,50 @@ func (c natsHeaderCarrier) Keys() []string {
 
 var _ propagation.TextMapCarrier = natsHeaderCarrier{}
 
-// publishWithSpan wraps conn.PublishMsg with a Producer span, injecting trace context into message headers.
-func publishWithSpan(ctx context.Context, conn *natsgo.Conn, subject string, data []byte) error {
-	ctx, span := tracer.Start(ctx, "nats.publish",
-		trace.WithSpanKind(trace.SpanKindProducer),
-		trace.WithAttributes(
-			attribute.String("messaging.system", "nats"),
-			attribute.String("messaging.destination.name", subject),
-			attribute.String("messaging.operation.type", "send"),
-			attribute.Int("messaging.message.body.size", len(data)),
-		),
-	)
-	defer span.End()
-
-	msg := natsgo.NewMsg(subject)
-	msg.Data = data
-	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
-
-	if err := conn.PublishMsg(msg); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return err
-	}
-	return nil
-}
-
-// requestWithSpan wraps conn.RequestMsgWithContext with a Client span, injecting trace context into message headers.
+// requestWithSpan performs a NATS RequestMsgWithContext with tracing.
 func requestWithSpan(ctx context.Context, conn *natsgo.Conn, subject string, data []byte) (*natsgo.Msg, error) {
 	ctx, span := tracer.Start(ctx, "nats.request",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "nats"),
 			attribute.String("messaging.destination.name", subject),
-			attribute.String("messaging.operation.type", "send"),
 			attribute.Int("messaging.message.body.size", len(data)),
 		),
 	)
 	defer span.End()
 
-	msg := natsgo.NewMsg(subject)
-	msg.Data = data
-	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
+	natsMsg := natsgo.NewMsg(subject)
+	natsMsg.Data = data
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(natsMsg.Header))
 
-	reply, err := conn.RequestMsgWithContext(ctx, msg)
+	msg, err := conn.RequestMsgWithContext(ctx, natsMsg)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return nil, err
 	}
-	return reply, nil
+	return msg, err
+}
+
+// publishWithSpan performs a NATS PublishMsg with tracing.
+func publishWithSpan(ctx context.Context, conn *natsgo.Conn, subject string, data []byte) error {
+	ctx, span := tracer.Start(ctx, "nats.publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", subject),
+			attribute.Int("messaging.message.body.size", len(data)),
+		),
+	)
+	defer span.End()
+
+	natsMsg := natsgo.NewMsg(subject)
+	natsMsg.Data = data
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(natsMsg.Header))
+
+	err := conn.PublishMsg(natsMsg)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
 }


### PR DESCRIPTION
adds OTel client spans to translator and project-lookup NATS request/reply calls, and OTel producer spans to all publish operations; references LFXV2-1743