### PR TITLE
fix: correct v1-sync mailing list visibility/audience_access mapping

### DIFF
--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -167,7 +167,7 @@ Published to `lfx.fga-sync.update_access` on create/update. Deleted via `lfx.fga
 | `group_id` | int64 (optional) | Groups.io numeric group ID |
 | `group_name` | string | Groups.io group name; emitted as empty string when not populated |
 | `public` | bool | Whether the mailing list is publicly accessible |
-| `audience_access` | string | Access model: `public`, `approval_required`, or `invite_only`; not populated by v1-sync transform — emitted as empty string |
+| `audience_access` | string | Access model: `public`, `approval_required`, or `invite_only` |
 | `source` | string | Source system identifier; always `"v1-sync"` for v1 datastream records |
 | `type` | string | List type: `announcement`, `discussion_moderated`, or `discussion_open` |
 | `subscriber_count` | int | Current number of subscribers |
@@ -185,7 +185,7 @@ Published to `lfx.fga-sync.update_access` on create/update. Deleted via `lfx.fga
 | `updated_at` | timestamp | Last update time (RFC3339) |
 | `system_updated_at` | timestamp (optional) | Last modified by a system process |
 
-> **v1-sync transform note:** `transformV1ToGrpsIOMailingList` populates `uid`, `group_id`, `group_name`, `public` (from `visibility`), `type`, `description`, `title`, `subject_tag`, `url`, `flags`, `service_uid` (from `parent_id`), `project_uid`, `source` ("v1-sync"), `subscriber_count`, `committees`, and timestamps. `audience_access`, `project_name`, and `project_slug` are not set by the transform and will be emitted as empty strings.
+> **v1-sync transform note:** `transformV1ToGrpsIOMailingList` populates `uid`, `group_id`, `group_name`, `public` and `audience_access` (both derived from `visibility`), `type`, `description`, `title`, `subject_tag`, `url`, `flags`, `service_uid` (from `parent_id`), `project_uid`, `source` ("v1-sync"), `subscriber_count`, `committees`, and timestamps. `project_name` and `project_slug` are not set by the transform and will be emitted as empty strings.
 
 ### Tags
 

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -286,6 +286,8 @@ func userInfoUsernames(users []model.UserInfo) []string {
 
 // transformV1ToGrpsIOMailingList maps v1 DynamoDB fields to the GrpsIOMailingList domain model.
 func transformV1ToGrpsIOMailingList(uid string, data map[string]any) *model.GroupsIOMailingList {
+	// visibility is the legacy ITX/DynamoDB field (itx-groupsio-v2-subgroup.visibility), synced
+	// verbatim via lfx-v1-sync-helper with no casing normalization upstream — hence EqualFold below.
 	visibility := mapconv.StringVal(data, "visibility")
 	list := &model.GroupsIOMailingList{
 		UID:            uid,

--- a/internal/service/datastream_subgroup_handler.go
+++ b/internal/service/datastream_subgroup_handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
@@ -285,20 +286,22 @@ func userInfoUsernames(users []model.UserInfo) []string {
 
 // transformV1ToGrpsIOMailingList maps v1 DynamoDB fields to the GrpsIOMailingList domain model.
 func transformV1ToGrpsIOMailingList(uid string, data map[string]any) *model.GroupsIOMailingList {
+	visibility := mapconv.StringVal(data, "visibility")
 	list := &model.GroupsIOMailingList{
-		UID:         uid,
-		GroupID:     mapconv.Int64Ptr(data, "group_id"),
-		GroupName:   mapconv.StringVal(data, "group_name"),
-		Public:      mapconv.StringVal(data, "visibility") == "Public",
-		Type:        mapconv.StringVal(data, "type"),
-		Description: mapconv.StringVal(data, "description"),
-		Title:       mapconv.StringVal(data, "title"),
-		SubjectTag:  mapconv.StringVal(data, "subject_tag"),
-		URL:         mapconv.StringVal(data, "url"),
-		Flags:       mapconv.StringSliceVal(data, "flags"),
-		ServiceUID:  mapconv.StringVal(data, "parent_id"),
-		ProjectUID:  mapconv.StringVal(data, "project_id"),
-		Source:      "v1-sync",
+		UID:            uid,
+		GroupID:        mapconv.Int64Ptr(data, "group_id"),
+		GroupName:      mapconv.StringVal(data, "group_name"),
+		Public:         strings.EqualFold(visibility, "public"),
+		AudienceAccess: visibility,
+		Type:           mapconv.StringVal(data, "type"),
+		Description:    mapconv.StringVal(data, "description"),
+		Title:          mapconv.StringVal(data, "title"),
+		SubjectTag:     mapconv.StringVal(data, "subject_tag"),
+		URL:            mapconv.StringVal(data, "url"),
+		Flags:          mapconv.StringSliceVal(data, "flags"),
+		ServiceUID:     mapconv.StringVal(data, "parent_id"),
+		ProjectUID:     mapconv.StringVal(data, "project_id"),
+		Source:         "v1-sync",
 	}
 
 	if n := mapconv.Int64Ptr(data, "subscriber_count"); n != nil {

--- a/internal/service/datastream_subgroup_handler_test.go
+++ b/internal/service/datastream_subgroup_handler_test.go
@@ -182,3 +182,33 @@ func TestHandleDataStreamSubgroupDelete_HappyPath_ACKAndTombstones(t *testing.T)
 	assert.True(t, m.IsTombstoned(context.Background(),
 		fmt.Sprintf("%s.sg-1", constants.KVMappingPrefixSubgroup)))
 }
+
+func TestTransformV1ToGrpsIOMailingList_VisibilityMapping(t *testing.T) {
+	tests := []struct {
+		name               string
+		visibility         any
+		wantPublic         bool
+		wantAudienceAccess string
+	}{
+		{"lowercase public", "public", true, "public"},
+		{"mixed-case Public", "Public", true, "Public"},
+		{"uppercase PUBLIC", "PUBLIC", true, "PUBLIC"},
+		{"approval_required", "approval_required", false, "approval_required"},
+		{"invite_only", "invite_only", false, "invite_only"},
+		{"missing visibility", nil, false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := map[string]any{}
+			if tt.visibility != nil {
+				data["visibility"] = tt.visibility
+			}
+
+			list := transformV1ToGrpsIOMailingList("sg-1", data)
+
+			assert.Equal(t, tt.wantPublic, list.Public)
+			assert.Equal(t, tt.wantAudienceAccess, list.AudienceAccess)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`transformV1ToGrpsIOMailingList` (`internal/service/datastream_subgroup_handler.go`) compared the raw v1 `visibility` field against the literal `"Public"` (wrong case) and never populated `AudienceAccess` at all. As a result, **every** GroupsIO mailing list synced from the legacy v1 system is indexed with `public: false, audience_access: ""`, regardless of its actual visibility — silently breaking search/access decisions that key off those fields.

Fix: read `visibility` once, set `AudienceAccess` to the raw pass-through value, and derive `Public` via a case-insensitive comparison (`strings.EqualFold(visibility, "public")`) so upstream casing drift can't cause this class of bug again.

Root cause confirmed end-to-end: `lfx-v1-sync-helper`'s `target-nats-kv` loader writes DynamoDB fields into `v1-objects` verbatim (no renaming/casing changes) — the misinterpretation happens entirely on read, in this repo.

Jira: [LFXV2-2603](https://linuxfoundation.atlassian.net/browse/LFXV2-2603)

## Evidence

**Bug reproduced live, both environments, 2026-07-07:**

- **Prod** — record `groupsio_mailing_list:151164` (source of truth via direct ITX API: `audience_access: "public"`) was indexed with `public: false, audience_access: ""`. Confirmed directly from the OpenSearch source doc (`GET resources/_doc/groupsio_mailing_list:151164`).
- **Prod, full population** — direct OpenSearch query across all 2690 non-deleted `groupsio_mailing_list` docs: **100% have `public: false`**, **0% have any non-empty `audience_access`**. This is not an edge case — it affects every v1-synced record.
- **Dev** — same pattern: 32 non-deleted v1-sync mailing lists, all `public: false, audience_access: ""`.

**Raw upstream value confirmed directly** (prod's `nats-box` pod exec is broken/OOM-killed, so this was read from dev instead via `kubectl port-forward svc/lfx-platform-nats 4222:4222` + `nats kv get`):

Raw `v1-objects` KV entries for three real, currently-buggy dev records (`itx-groupsio-v2-subgroup.147952`, `.147949`, `.148023`) all contain:
```json
"visibility": "public"
```
lowercase, verbatim — confirming the root cause exactly: a case-sensitive comparison against the wrong literal casing, not a mistaken model of the data.

**Fix verified against a real record:** fed record 147952's exact raw KV JSON through the fixed `transformV1ToGrpsIOMailingList` in a local test — now correctly yields `Public: true, AudienceAccess: "public"` (previously `false`/`""`).

## Test plan

- [x] Added table-driven unit tests (`TestTransformV1ToGrpsIOMailingList_VisibilityMapping`) covering lowercase/mixed-case/uppercase `"public"`, `"approval_required"`, `"invite_only"`, and missing `visibility` — confirmed these fail against the old code before the fix, pass after.
- [x] `go test ./internal/service/...` — all pass.
- [x] `make lint` — clean.
- [x] `make test` (full suite) — pass, no regressions.
- [x] Reproduced the ticket's exact record (group_id 151164) and a real dev record (147952) through the fixed transform — both now yield the correct `Public`/`AudienceAccess`.
- [ ] After deploy, run `scripts/reindex_mailing_lists -types groupsio_mailing_list` (dry-run, then `-reindex`) per environment to backfill already-indexed stale documents — no source-of-truth data mutation needed, this only re-triggers indexing through the fixed code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2603]: https://linuxfoundation.atlassian.net/browse/LFXV2-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ