### PR TITLE
fix: remove stale FGA access when member username is cleared on update

### DIFF
--- a/internal/infrastructure/mock/mapping_store.go
+++ b/internal/infrastructure/mock/mapping_store.go
@@ -14,17 +14,26 @@ import (
 type FakeMappingStore struct {
 	values     map[string]string
 	tombstones map[string]bool
+	getErrors  map[string]bool
 }
 
 var _ port.MappingReaderWriter = (*FakeMappingStore)(nil)
 
 // NewFakeMappingStore returns an empty FakeMappingStore.
 func NewFakeMappingStore() *FakeMappingStore {
-	return &FakeMappingStore{values: make(map[string]string), tombstones: make(map[string]bool)}
+	return &FakeMappingStore{
+		values:    make(map[string]string),
+		tombstones: make(map[string]bool),
+		getErrors: make(map[string]bool),
+	}
 }
 
 // Set pre-populates a key/value pair (helper for test setup).
 func (f *FakeMappingStore) Set(key, value string) { f.values[key] = value }
+
+// SimulateGetError causes GetMappingValue to return ("", false) for the given key,
+// simulating a transient KV read error even when the key exists.
+func (f *FakeMappingStore) SimulateGetError(key string) { f.getErrors[key] = true }
 
 func (f *FakeMappingStore) ResolveAction(_ context.Context, key string) model.MessageAction {
 	if _, ok := f.values[key]; ok {
@@ -43,7 +52,7 @@ func (f *FakeMappingStore) IsTombstoned(_ context.Context, key string) bool {
 }
 
 func (f *FakeMappingStore) GetMappingValue(_ context.Context, key string) (string, bool) {
-	if f.tombstones[key] {
+	if f.tombstones[key] || f.getErrors[key] {
 		return "", false
 	}
 	v, ok := f.values[key]

--- a/internal/infrastructure/mock/mapping_store.go
+++ b/internal/infrastructure/mock/mapping_store.go
@@ -12,9 +12,10 @@ import (
 
 // FakeMappingStore is an in-memory MappingReaderWriter for unit tests.
 type FakeMappingStore struct {
-	values     map[string]string
-	tombstones map[string]bool
-	getErrors  map[string]bool
+	values      map[string]string
+	tombstones  map[string]bool
+	getErrors   map[string]bool
+	putErrors   map[string]error
 }
 
 var _ port.MappingReaderWriter = (*FakeMappingStore)(nil)
@@ -22,9 +23,10 @@ var _ port.MappingReaderWriter = (*FakeMappingStore)(nil)
 // NewFakeMappingStore returns an empty FakeMappingStore.
 func NewFakeMappingStore() *FakeMappingStore {
 	return &FakeMappingStore{
-		values:    make(map[string]string),
+		values:     make(map[string]string),
 		tombstones: make(map[string]bool),
-		getErrors: make(map[string]bool),
+		getErrors:  make(map[string]bool),
+		putErrors:  make(map[string]error),
 	}
 }
 
@@ -34,6 +36,9 @@ func (f *FakeMappingStore) Set(key, value string) { f.values[key] = value }
 // SimulateGetError causes GetMappingValue to return ("", false) for the given key,
 // simulating a transient KV read error even when the key exists.
 func (f *FakeMappingStore) SimulateGetError(key string) { f.getErrors[key] = true }
+
+// SimulatePutError causes PutMapping to return the given error for the given key.
+func (f *FakeMappingStore) SimulatePutError(key string, err error) { f.putErrors[key] = err }
 
 func (f *FakeMappingStore) ResolveAction(_ context.Context, key string) model.MessageAction {
 	if _, ok := f.values[key]; ok {
@@ -60,6 +65,9 @@ func (f *FakeMappingStore) GetMappingValue(_ context.Context, key string) (strin
 }
 
 func (f *FakeMappingStore) PutMapping(_ context.Context, key, value string) error {
+	if err, ok := f.putErrors[key]; ok {
+		return err
+	}
 	f.values[key] = value
 	return nil
 }

--- a/internal/infrastructure/mock/message_publisher.go
+++ b/internal/infrastructure/mock/message_publisher.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SpyMessagePublisher records every call to Indexer and Access for assertion in tests.
-// Set AccessError or IndexerError to inject failures on the next matching call.
+// Set AccessError or IndexerError to inject a failure returned on every subsequent matching call.
 type SpyMessagePublisher struct {
 	IndexerCalls []PublishedMsg
 	AccessCalls  []PublishedMsg

--- a/internal/infrastructure/mock/message_publisher.go
+++ b/internal/infrastructure/mock/message_publisher.go
@@ -11,9 +11,14 @@ import (
 )
 
 // SpyMessagePublisher records every call to Indexer and Access for assertion in tests.
+// Set AccessError or IndexerError to inject failures on the next matching call.
 type SpyMessagePublisher struct {
 	IndexerCalls []PublishedMsg
 	AccessCalls  []PublishedMsg
+	// AccessError, if non-nil, is returned by every Access call.
+	AccessError error
+	// IndexerError, if non-nil, is returned by every Indexer call.
+	IndexerError error
 }
 
 // PublishedMsg holds the subject and message from a single publisher call.
@@ -26,11 +31,11 @@ var _ port.MessagePublisher = (*SpyMessagePublisher)(nil)
 
 func (s *SpyMessagePublisher) Indexer(_ context.Context, subject string, message any) error {
 	s.IndexerCalls = append(s.IndexerCalls, PublishedMsg{subject, message})
-	return nil
+	return s.IndexerError
 }
 func (s *SpyMessagePublisher) Access(_ context.Context, subject string, message any) error {
 	s.AccessCalls = append(s.AccessCalls, PublishedMsg{subject, message})
-	return nil
+	return s.AccessError
 }
 func (s *SpyMessagePublisher) Internal(_ context.Context, _ string, _ any) error { return nil }
 

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -107,6 +107,8 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 
 	// If the username was removed or changed, revoke the old FGA access before granting new
 	// access so the user never holds more permissions than intended.
+	// Retry transient publish failures: if we continue and overwrite the mapping, the old
+	// username is lost and the stale tuple can never be recovered.
 	if oldUsername != "" && oldUsername != member.Username {
 		removeMsg := fgatypes.GenericFGAMessage{
 			ObjectType: constants.ObjectTypeGroupsIOMailingList,
@@ -119,6 +121,7 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 		}
 		if err := publisher.Access(ctx, fgaconstants.GenericMemberRemoveSubject, removeMsg); err != nil {
 			slog.WarnContext(ctx, "failed to publish member FGA remove for old username", "uid", uid, "error", err)
+			return pkgerrors.IsTransient(err)
 		}
 	}
 

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -37,7 +37,7 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 
 	gidKey := fmt.Sprintf("%s.%d", constants.KVMappingPrefixSubgroupByGroupID, *groupID)
 	mailingListUID, ok := mappings.GetMappingValue(ctx, gidKey)
-	if !ok {
+	if !ok || mailingListUID == "" {
 		slog.WarnContext(ctx, "parent subgroup not yet processed, NAKing member for retry",
 			"uid", uid, "group_id", *groupID)
 		return true // NAK — retry with backoff
@@ -79,6 +79,13 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 	if storedValue, ok := mappings.GetMappingValue(ctx, mKey); ok {
 		action = model.ActionUpdated
 		_, oldUsername, oldMailingListUID = parseMemberMappingValue(storedValue)
+		// Warn when the stored mapping is missing the mailing list UID (written by an older
+		// version of the handler). Parent-change FGA revocation cannot fire without it —
+		// reprocess the member or run a mapping backfill to repair affected entries.
+		if oldUsername != "" && oldMailingListUID == "" {
+			slog.WarnContext(ctx, "stored member mapping lacks mailing list UID — parent-change FGA revocation disabled for this entry",
+				"uid", uid)
+		}
 	}
 
 	member := transformV1ToGrpsIOMember(uid, mailingListUID, projectUID, projectSlug, data)

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -68,13 +68,19 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 
 	action := mappings.ResolveAction(ctx, mKey)
 
-	// For updates, read the previously-stored username so we can detect when it has been
-	// cleared and revoke stale FGA access before writing the new state.
+	// For updates, read the previously-stored username and mailing list UID so we can detect
+	// when either has changed and revoke stale FGA access before writing the new state.
 	oldUsername := ""
+	oldMailingListUID := ""
 	if action == model.ActionUpdated {
-		if storedValue, ok := mappings.GetMappingValue(ctx, mKey); ok {
-			_, oldUsername, _ = parseMemberMappingValue(storedValue)
+		storedValue, ok := mappings.GetMappingValue(ctx, mKey)
+		if !ok {
+			// ResolveAction confirmed a live mapping exists; GetMappingValue returning false
+			// indicates a transient KV read error. NAK so the event is redelivered.
+			slog.WarnContext(ctx, "failed to read existing member mapping, NAKing for retry", "uid", uid)
+			return true
 		}
+		_, oldUsername, oldMailingListUID = parseMemberMappingValue(storedValue)
 	}
 
 	member := transformV1ToGrpsIOMember(uid, mailingListUID, projectUID, projectSlug, data)
@@ -105,16 +111,23 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 		return pkgerrors.IsTransient(err)
 	}
 
-	// If the username was removed or changed, revoke the old FGA access before granting new
-	// access so the user never holds more permissions than intended.
-	// Retry transient publish failures: if we continue and overwrite the mapping, the old
-	// username is lost and the stale tuple can never be recovered.
-	if oldUsername != "" && oldUsername != member.Username {
+	// If the username or parent mailing list changed, revoke the old FGA tuple before
+	// granting the new one. Use the stored mailing list UID so the remove targets the
+	// correct group even when the member moved groups.
+	// Retry transient publish failures: continuing would overwrite the mapping and lose
+	// the old username, making the stale tuple unrecoverable.
+	usernameChanged := oldUsername != "" && oldUsername != member.Username
+	parentChanged := oldUsername != "" && oldMailingListUID != "" && oldMailingListUID != mailingListUID
+	if usernameChanged || parentChanged {
+		removeUID := oldMailingListUID
+		if removeUID == "" {
+			removeUID = mailingListUID
+		}
 		removeMsg := fgatypes.GenericFGAMessage{
 			ObjectType: constants.ObjectTypeGroupsIOMailingList,
 			Operation:  "member_remove",
 			Data: fgatypes.GenericMemberData{
-				UID:       mailingListUID,
+				UID:       removeUID,
 				Username:  oldUsername,
 				Relations: []string{},
 			},

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -68,6 +68,15 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 
 	action := mappings.ResolveAction(ctx, mKey)
 
+	// For updates, read the previously-stored username so we can detect when it has been
+	// cleared and revoke stale FGA access before writing the new state.
+	oldUsername := ""
+	if action == model.ActionUpdated {
+		if storedValue, ok := mappings.GetMappingValue(ctx, mKey); ok {
+			_, oldUsername, _ = parseMemberMappingValue(storedValue)
+		}
+	}
+
 	member := transformV1ToGrpsIOMember(uid, mailingListUID, projectUID, projectSlug, data)
 
 	mailingListRef := fmt.Sprintf("groupsio_mailing_list:%s", mailingListUID)
@@ -94,6 +103,23 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 	if err := publisher.Indexer(ctx, constants.IndexGroupsIOMemberSubject, built); err != nil {
 		slog.ErrorContext(ctx, "failed to publish member indexer message", "uid", uid, "error", err)
 		return pkgerrors.IsTransient(err)
+	}
+
+	// If the username was removed or changed, revoke the old FGA access before granting new
+	// access so the user never holds more permissions than intended.
+	if oldUsername != "" && oldUsername != member.Username {
+		removeMsg := fgatypes.GenericFGAMessage{
+			ObjectType: constants.ObjectTypeGroupsIOMailingList,
+			Operation:  "member_remove",
+			Data: fgatypes.GenericMemberData{
+				UID:       mailingListUID,
+				Username:  oldUsername,
+				Relations: []string{},
+			},
+		}
+		if err := publisher.Access(ctx, fgaconstants.GenericMemberRemoveSubject, removeMsg); err != nil {
+			slog.WarnContext(ctx, "failed to publish member FGA remove for old username", "uid", uid, "error", err)
+		}
 	}
 
 	if member.Username != "" {

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -75,17 +75,9 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 	// (tracked as a follow-up interface change).
 	action := model.ActionCreated
 	oldUsername := ""
-	oldMailingListUID := ""
 	if storedValue, ok := mappings.GetMappingValue(ctx, mKey); ok {
 		action = model.ActionUpdated
-		_, oldUsername, oldMailingListUID = parseMemberMappingValue(storedValue)
-		// Warn when the stored mapping is missing the mailing list UID (written by an older
-		// version of the handler). Parent-change FGA revocation cannot fire without it —
-		// reprocess the member or run a mapping backfill to repair affected entries.
-		if oldUsername != "" && oldMailingListUID == "" {
-			slog.WarnContext(ctx, "stored member mapping lacks mailing list UID — parent-change FGA revocation disabled for this entry",
-				"uid", uid)
-		}
+		_, oldUsername, _ = parseMemberMappingValue(storedValue)
 	}
 
 	member := transformV1ToGrpsIOMember(uid, mailingListUID, projectUID, projectSlug, data)
@@ -116,23 +108,17 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 		return pkgerrors.IsTransient(err)
 	}
 
-	// If the username or parent mailing list changed, revoke the old FGA tuple before
-	// granting the new one. Use the stored mailing list UID so the remove targets the
-	// correct group even when the member moved groups.
+	// Revoke the old FGA tuple before granting the new one when the username changes or
+	// is cleared. A member record's group_id (and therefore mailingListUID) is immutable,
+	// so the remove always targets the same mailing list as the put.
 	// Retry transient publish failures: continuing would overwrite the mapping and lose
 	// the old username, making the stale tuple unrecoverable.
-	usernameChanged := oldUsername != "" && oldUsername != member.Username
-	parentChanged := oldUsername != "" && oldMailingListUID != "" && oldMailingListUID != mailingListUID
-	if usernameChanged || parentChanged {
-		removeUID := oldMailingListUID
-		if removeUID == "" {
-			removeUID = mailingListUID
-		}
+	if oldUsername != "" && oldUsername != member.Username {
 		removeMsg := fgatypes.GenericFGAMessage{
 			ObjectType: constants.ObjectTypeGroupsIOMailingList,
 			Operation:  "member_remove",
 			Data: fgatypes.GenericMemberData{
-				UID:       removeUID,
+				UID:       mailingListUID,
 				Username:  oldUsername,
 				Relations: []string{},
 			},

--- a/internal/service/datastream_member_handler.go
+++ b/internal/service/datastream_member_handler.go
@@ -66,20 +66,18 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 		return false
 	}
 
-	action := mappings.ResolveAction(ctx, mKey)
-
-	// For updates, read the previously-stored username and mailing list UID so we can detect
-	// when either has changed and revoke stale FGA access before writing the new state.
+	// Single read: determine action and capture old state in one call.
+	// ResolveAction also calls kv.Get internally and converts any error into ActionCreated,
+	// which would silently bypass stale-tuple removal. Using GetMappingValue directly avoids
+	// that hidden failure path. The interface cannot yet distinguish "key not found" from a
+	// transient storage error — both return false — so a transient failure here still
+	// produces ActionCreated. A proper NAK requires adding error return to MappingReader
+	// (tracked as a follow-up interface change).
+	action := model.ActionCreated
 	oldUsername := ""
 	oldMailingListUID := ""
-	if action == model.ActionUpdated {
-		storedValue, ok := mappings.GetMappingValue(ctx, mKey)
-		if !ok {
-			// ResolveAction confirmed a live mapping exists; GetMappingValue returning false
-			// indicates a transient KV read error. NAK so the event is redelivered.
-			slog.WarnContext(ctx, "failed to read existing member mapping, NAKing for retry", "uid", uid)
-			return true
-		}
+	if storedValue, ok := mappings.GetMappingValue(ctx, mKey); ok {
+		action = model.ActionUpdated
 		_, oldUsername, oldMailingListUID = parseMemberMappingValue(storedValue)
 	}
 
@@ -150,12 +148,14 @@ func HandleDataStreamMemberUpdate(ctx context.Context, uid string, data map[stri
 		}
 		if err := publisher.Access(ctx, fgaconstants.GenericMemberPutSubject, accessMsg); err != nil {
 			slog.WarnContext(ctx, "failed to publish member FGA put message", "uid", uid, "error", err)
+			return pkgerrors.IsTransient(err)
 		}
 	}
 
 	mappingValue := buildMemberMappingValue(uid, member.Username, mailingListUID)
 	if err := mappings.PutMapping(ctx, mKey, mappingValue); err != nil {
 		slog.ErrorContext(ctx, "failed to put mapping key", "mapping_key", mKey, "error", err)
+		return pkgerrors.IsTransient(err)
 	}
 
 	// Best-effort: send an LFID invite for newly-created members without a username.

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -227,6 +227,73 @@ func TestHandleDataStreamMemberUpdate_WithLFXHandleUsername_PublishesMemberPut(t
 	assert.Equal(t, "alice.smith", data.Username)
 }
 
+func TestHandleDataStreamMemberUpdate_UsernameCleared_PublishesMemberRemove(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
+	// Pre-existing mapping with username stored
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-1")
+
+	pub := &mock.SpyMessagePublisher{}
+	// Update arrives with username removed
+	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
+		map[string]any{
+			"group_id":  float64(42),
+			"full_name": "Alice Smith",
+			// username intentionally absent
+		},
+		pub, m, nil)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	// Should have exactly one access call: member_remove for the old username
+	assert.Len(t, pub.AccessCalls, 1)
+	assert.Equal(t, fgaconstants.GenericMemberRemoveSubject, pub.AccessCalls[0].Subject)
+
+	msg, ok := pub.AccessCalls[0].Message.(fgatypes.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, "member_remove", msg.Operation)
+	data, ok := msg.Data.(fgatypes.GenericMemberData)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-1", data.UID)
+	assert.Equal(t, "alice@example.com", data.Username)
+	assert.Empty(t, data.Relations)
+}
+
+func TestHandleDataStreamMemberUpdate_UsernameChanged_RemovesOldAndAddsNew(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-1")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
+		map[string]any{
+			"group_id":  float64(42),
+			"username":  "bob@example.com",
+			"full_name": "Bob Jones",
+		},
+		pub, m, nil)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	// remove for old username, then put for new username
+	assert.Len(t, pub.AccessCalls, 2)
+	assert.Equal(t, fgaconstants.GenericMemberRemoveSubject, pub.AccessCalls[0].Subject)
+	removeData, ok := pub.AccessCalls[0].Message.(fgatypes.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, "alice@example.com", removeData.Data.(fgatypes.GenericMemberData).Username)
+
+	assert.Equal(t, fgaconstants.GenericMemberPutSubject, pub.AccessCalls[1].Subject)
+	putData, ok := pub.AccessCalls[1].Message.(fgatypes.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, "bob@example.com", putData.Data.(fgatypes.GenericMemberData).Username)
+}
+
 func TestHandleDataStreamMemberDelete_WithUsername_PublishesMemberRemove(t *testing.T) {
 	m := mock.NewFakeMappingStore()
 	ctx := context.Background()

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -294,24 +295,64 @@ func TestHandleDataStreamMemberUpdate_UsernameChanged_RemovesOldAndAddsNew(t *te
 	assert.Equal(t, "bob@example.com", putData.Data.(fgatypes.GenericMemberData).Username)
 }
 
-func TestHandleDataStreamMemberUpdate_MappingReadError_NAK(t *testing.T) {
+func TestHandleDataStreamMemberUpdate_MappingReadError_TreatedAsCreate(t *testing.T) {
+	// When GetMappingValue returns false (including on transient KV error), the handler cannot
+	// distinguish "not found" from "error" — it treats the event as ActionCreated and skips
+	// any stale-tuple removal. This is an accepted limitation pending an interface change that
+	// exposes the raw error.
 	m := mock.NewFakeMappingStore()
 	ctx := context.Background()
 	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
 	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
-	// Key exists (so ResolveAction returns ActionUpdated) but GetMappingValue will fail
 	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
 	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-1")
 	m.SimulateGetError(mKey)
 
 	pub := &mock.SpyMessagePublisher{}
 	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
+		map[string]any{"group_id": float64(42), "username": "bob@example.com"},
+		pub, m, nil)
+
+	// ACKed — no NAK since we can't distinguish transient from not-found without interface change.
+	assert.False(t, nak)
+	// No remove: oldUsername is unknown, so we cannot revoke the stale tuple.
+	assert.Equal(t, 1, len(pub.AccessCalls), "only member_put should be published — no remove since old username is unknown")
+	assert.Equal(t, fgaconstants.GenericMemberPutSubject, pub.AccessCalls[0].Subject)
+}
+
+func TestHandleDataStreamMemberUpdate_MemberPutFailure_Transient_NAK(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
+
+	pub := &mock.SpyMessagePublisher{AccessError: errors.New("connection refused")}
+	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
 		map[string]any{"group_id": float64(42), "username": "alice@example.com"},
 		pub, m, nil)
 
-	assert.True(t, nak, "transient mapping read error should NAK for retry")
-	assert.Empty(t, pub.IndexerCalls, "should not publish when mapping is unreadable")
-	assert.Empty(t, pub.AccessCalls)
+	assert.True(t, nak, "transient member_put failure should NAK for retry")
+	// Mapping must NOT have been written — redelivery needs to retry member_put too.
+	_, mappingWritten := m.GetMappingValue(ctx, fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember))
+	assert.False(t, mappingWritten, "mapping must not be written when member_put fails")
+}
+
+func TestHandleDataStreamMemberUpdate_PutMappingFailure_Transient_NAK(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	m.SimulatePutError(mKey, errors.New("connection timeout"))
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
+		map[string]any{"group_id": float64(42), "username": "alice@example.com"},
+		pub, m, nil)
+
+	assert.True(t, nak, "transient PutMapping failure should NAK for retry")
+	// FGA put was already published — redelivery will resend it, which is idempotent.
+	assert.Len(t, pub.AccessCalls, 1, "member_put was published before the mapping write failed")
 }
 
 func TestHandleDataStreamMemberUpdate_MailingListChanged_RemovesOldTuple(t *testing.T) {

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -355,35 +355,6 @@ func TestHandleDataStreamMemberUpdate_PutMappingFailure_Transient_NAK(t *testing
 	assert.Len(t, pub.AccessCalls, 1, "member_put was published before the mapping write failed")
 }
 
-func TestHandleDataStreamMemberUpdate_MailingListChanged_RemovesOldTuple(t *testing.T) {
-	m := mock.NewFakeMappingStore()
-	ctx := context.Background()
-	// Member was previously in sg-old, now arriving under sg-new
-	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-new")
-	setProjectMapping(m, "sg-new", "proj-uid", "my-project")
-	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
-	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-old")
-
-	pub := &mock.SpyMessagePublisher{}
-	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
-		map[string]any{"group_id": float64(42), "username": "alice@example.com"},
-		pub, m, nil)
-
-	assert.False(t, nak)
-	assert.Len(t, pub.IndexerCalls, 1)
-	// remove for old (sg-old, alice), then put for new (sg-new, alice)
-	assert.Len(t, pub.AccessCalls, 2)
-	assert.Equal(t, fgaconstants.GenericMemberRemoveSubject, pub.AccessCalls[0].Subject)
-	removeData, ok := pub.AccessCalls[0].Message.(fgatypes.GenericFGAMessage)
-	assert.True(t, ok)
-	assert.Equal(t, "sg-old", removeData.Data.(fgatypes.GenericMemberData).UID)
-	assert.Equal(t, "alice@example.com", removeData.Data.(fgatypes.GenericMemberData).Username)
-
-	assert.Equal(t, fgaconstants.GenericMemberPutSubject, pub.AccessCalls[1].Subject)
-	putData, ok := pub.AccessCalls[1].Message.(fgatypes.GenericFGAMessage)
-	assert.True(t, ok)
-	assert.Equal(t, "sg-new", putData.Data.(fgatypes.GenericMemberData).UID)
-}
 
 func TestHandleDataStreamMemberDelete_WithUsername_PublishesMemberRemove(t *testing.T) {
 	m := mock.NewFakeMappingStore()

--- a/internal/service/datastream_member_handler_test.go
+++ b/internal/service/datastream_member_handler_test.go
@@ -294,6 +294,56 @@ func TestHandleDataStreamMemberUpdate_UsernameChanged_RemovesOldAndAddsNew(t *te
 	assert.Equal(t, "bob@example.com", putData.Data.(fgatypes.GenericMemberData).Username)
 }
 
+func TestHandleDataStreamMemberUpdate_MappingReadError_NAK(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-1")
+	setProjectMapping(m, "sg-1", "proj-uid", "my-project")
+	// Key exists (so ResolveAction returns ActionUpdated) but GetMappingValue will fail
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-1")
+	m.SimulateGetError(mKey)
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
+		map[string]any{"group_id": float64(42), "username": "alice@example.com"},
+		pub, m, nil)
+
+	assert.True(t, nak, "transient mapping read error should NAK for retry")
+	assert.Empty(t, pub.IndexerCalls, "should not publish when mapping is unreadable")
+	assert.Empty(t, pub.AccessCalls)
+}
+
+func TestHandleDataStreamMemberUpdate_MailingListChanged_RemovesOldTuple(t *testing.T) {
+	m := mock.NewFakeMappingStore()
+	ctx := context.Background()
+	// Member was previously in sg-old, now arriving under sg-new
+	m.Set(fmt.Sprintf("%s.42", constants.KVMappingPrefixSubgroupByGroupID), "sg-new")
+	setProjectMapping(m, "sg-new", "proj-uid", "my-project")
+	mKey := fmt.Sprintf("%s.mem-1", constants.KVMappingPrefixMember)
+	_ = m.PutMapping(ctx, mKey, "mem-1|alice@example.com|sg-old")
+
+	pub := &mock.SpyMessagePublisher{}
+	nak := HandleDataStreamMemberUpdate(ctx, "mem-1",
+		map[string]any{"group_id": float64(42), "username": "alice@example.com"},
+		pub, m, nil)
+
+	assert.False(t, nak)
+	assert.Len(t, pub.IndexerCalls, 1)
+	// remove for old (sg-old, alice), then put for new (sg-new, alice)
+	assert.Len(t, pub.AccessCalls, 2)
+	assert.Equal(t, fgaconstants.GenericMemberRemoveSubject, pub.AccessCalls[0].Subject)
+	removeData, ok := pub.AccessCalls[0].Message.(fgatypes.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-old", removeData.Data.(fgatypes.GenericMemberData).UID)
+	assert.Equal(t, "alice@example.com", removeData.Data.(fgatypes.GenericMemberData).Username)
+
+	assert.Equal(t, fgaconstants.GenericMemberPutSubject, pub.AccessCalls[1].Subject)
+	putData, ok := pub.AccessCalls[1].Message.(fgatypes.GenericFGAMessage)
+	assert.True(t, ok)
+	assert.Equal(t, "sg-new", putData.Data.(fgatypes.GenericMemberData).UID)
+}
+
 func TestHandleDataStreamMemberDelete_WithUsername_PublishesMemberRemove(t *testing.T) {
 	m := mock.NewFakeMappingStore()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- When a mailing list member record was updated with its username removed, the \`member_put\` was correctly skipped but no \`member_remove\` was sent for the old username — the stale OpenFGA tuple persisted indefinitely
- The delete handler already handled this correctly (reading the stored username from the mapping and sending \`member_remove\`), but the update path did not
- Fix: before publishing the new state, read the previously-stored mapping value to extract the old username. If it differs from the new username (including when cleared), send a \`member_remove\` for the old username before the \`member_put\` for the new one
- Tests added for username-cleared and username-changed scenarios

## Ticket

[LFXV2-2619](https://linuxfoundation.atlassian.net/browse/LFXV2-2619)

## Test plan

- [ ] Update a mailing list member in staging to remove their username — confirm the old OpenFGA tuple is removed
- [ ] Update a member to change their username — confirm the old tuple is removed and a new one is added
- [ ] Verify existing member create/update flows are unaffected
- [ ] Confirm the delete path still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2619]: https://linuxfoundation.atlassian.net/browse/LFXV2-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ